### PR TITLE
Add preproc IF config for PC debug

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -3979,7 +3979,6 @@ static void DebugAction_PartyBoxes_AccessPC(u8 taskId)
 {
     gIsDebugPC = TRUE;
     Debug_DestroyMenu_Full_Script(taskId, EventScript_PC);
-    //gIsDebugPC = FALSE;
 }
 
 static void DebugAction_PartyBoxes_MoveReminder(u8 taskId)

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -34,6 +34,7 @@
 #include "party_menu.h"
 #include "dynamic_placeholder_text_util.h"
 #include "new_menu_helpers.h"
+#include "config/debug.h"
 #include "constants/songs.h"
 #include "constants/items.h"
 #include "constants/maps.h"
@@ -214,8 +215,10 @@ void AnimatePcTurnOn(void)
 {
     u8 taskId;
 
+#if DEBUG_OVERWORLD_MENU == TRUE
     if (gIsDebugPC)
         return;
+#endif
 
     if (FuncIsActiveTask(Task_AnimatePcTurnOn) != TRUE)
     {
@@ -294,11 +297,13 @@ void AnimatePcTurnOff()
     s8 deltaY = 0;
     u8 direction = GetPlayerFacingDirection();
 
+#if DEBUG_OVERWORLD_MENU == TRUE
     if (gIsDebugPC)
     {
         gIsDebugPC = FALSE;
         return;
     }
+#endif
 
     switch (direction)
     {


### PR DESCRIPTION
This fixes an issue where the build would error if the debug menu preproc constant is set to false.