### PR TITLE
Clean up debug menu and set debug flags

### DIFF
--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -91,7 +91,6 @@ Debug_BoxFilledMessage_Text:
 	.string "Storage boxes filled!$"
 
 Debug_EventScript_Script_1::
-	giveegg SPECIES_TORCHIC
 	end
 
 Debug_EventScript_Script_2::

--- a/include/config/debug.h
+++ b/include/config/debug.h
@@ -5,10 +5,6 @@
 #define DEBUG_OVERWORLD_MENU            TRUE                // Enables an overworld debug menu to change flags, variables, giving pokemon and more, accessed by holding R and pressing START while in the overworld by default.
 #define DEBUG_OVERWORLD_HELD_KEYS       (R_BUTTON)          // The keys required to be held to open the debug menu.
 #define DEBUG_OVERWORLD_TRIGGER_EVENT   pressedStartButton  // The event that opens the menu when holding the key(s) defined in DEBUG_OVERWORLD_HELD_KEYS.
-#define DEBUG_OVERWORLD_IN_MENU         TRUE                // Replaces the overworld debug menu button combination with a start menu entry (above Pokédex).
-
-// todo
-// Pokémon Debug
-//#define DEBUG_POKEMON_MENU              TRUE    // Enables a debug menu for pokemon sprites and icons, accessed by pressing SELECT in the summary screen.
+#define DEBUG_OVERWORLD_IN_MENU         TRUE                // Replaces the overworld debug menu button combination with a start menu entry (above Pokédex)
 
 #endif // GUARD_CONFIG_DEBUG_H

--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -4,9 +4,9 @@
 // Overworld flags
 // To use the following features in scripting, replace the 0s with the flag ID you're assigning it to.
 // Eg: Replace with FLAG_UNUSED_0x264 so you can use that flag to toggle the feature.
-#define OW_FLAG_NO_ENCOUNTER            0       // If this flag is set, wild encounters will be disabled.
-#define OW_FLAG_NO_TRAINER_SEE          0       // If this flag is set, trainers will not battle the player unless they're talked to.
-#define OW_FLAG_NO_COLLISION            0       // If this flag is set, the player will be able to walk over tiles with collision. Mainly intended for debugging purposes.
-#define OW_FLAG_DISABLE_QUEST_LOG       0       // If this flag is set, the quest log will never appear
+#define OW_FLAG_NO_ENCOUNTER            FLAG_CSR_DEBUG_NO_ENCOUNTER     // If this flag is set, wild encounters will be disabled.
+#define OW_FLAG_NO_TRAINER_SEE          FLAG_CSR_DEBUG_NO_TRAINER_SEE   // If this flag is set, trainers will not battle the player unless they're talked to.
+#define OW_FLAG_NO_COLLISION            FLAG_CSR_DEBUG_NO_COLLISION     // If this flag is set, the player will be able to walk over tiles with collision. Mainly intended for debugging purposes.
+#define OW_FLAG_DISABLE_QUEST_LOG       FLAG_CSR_DEBUG_NO_QUEST_LOG     // If this flag is set, the quest log will never appear
 
 #endif // GUARD_CONFIG_OVERWORLD_H

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -820,10 +820,10 @@
 #define FLAG_OAKS_RATING_IS_VIA_PC                       0x2FF
 
 // Unused?
-#define FLAG_0x300               0x300
-#define FLAG_0x301               0x301
-#define FLAG_0x302               0x302
-#define FLAG_0x303               0x303
+#define FLAG_CSR_DEBUG_NO_ENCOUNTER               0x300
+#define FLAG_CSR_DEBUG_NO_TRAINER_SEE             0x301
+#define FLAG_CSR_DEBUG_NO_COLLISION               0x302
+#define FLAG_CSR_DEBUG_NO_QUEST_LOG               0x303
 #define FLAG_0x304               0x304
 #define FLAG_0x305               0x305
 #define FLAG_0x306               0x306


### PR DESCRIPTION
This removes some leftover stuff in the debug menu (old comment & one script) and sets default flags for the overworld features.