### PR TITLE
Change level up moves to use a struct instead of bitmasks

### DIFF
--- a/include/constants/pokemon.h
+++ b/include/constants/pokemon.h
@@ -218,9 +218,7 @@
 #define MON_ALREADY_KNOWS_MOVE 0xFFFE
 #define MON_HAS_MAX_MOVES      0xFFFF
 
-#define LEVEL_UP_MOVE_ID   0x01FF
-#define LEVEL_UP_MOVE_LV   0xFE00
-#define LEVEL_UP_END       0xFFFF
+#define LEVEL_UP_MOVE_END 0xFFFF
 
 #define MAX_LEVEL_UP_MOVES       20
 

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -260,10 +260,10 @@ struct SpindaSpot
     u16 image[SPINDA_SPOT_HEIGHT];
 };
 
-struct __attribute__((packed)) LevelUpMove
+struct LevelUpMove
 {
-    u16 move:9;
-    u16 level:7;
+    u16 move;
+    u16 level;
 };
 
 struct Evolution
@@ -295,7 +295,7 @@ extern const u8 gStatStageRatios[][2];
 extern struct SpriteTemplate gMultiuseSpriteTemplate;
 extern struct PokemonStorage* gPokemonStoragePtr;
 extern const u32 gExperienceTables[][MAX_LEVEL + 1];
-extern const u16 *const gLevelUpLearnsets[];
+extern const struct LevelUpMove *const gLevelUpLearnsets[];
 extern const u8 gFacilityClassToPicIndex[];
 extern const u8 gFacilityClassToTrainerClass[];
 extern const struct SpriteTemplate gSpriteTemplates_Battlers[];
@@ -365,7 +365,7 @@ u8 GetSecretBaseTrainerPicIndex(void);
 u8 GetSecretBaseTrainerNameIndex(void);
 bool8 IsPlayerPartyAndPokemonStorageFull(void);
 void GetSpeciesName(u8 *name, u16 species);
-const u16 *GetSpeciesLevelUpLearnset(u16 species);
+const struct LevelUpMove *GetSpeciesLevelUpLearnset(u16 species);
 u8 CalculatePPWithBonus(u16 move, u8 ppBonuses, u8 moveIndex);
 void RemoveMonPPBonus(struct Pokemon *mon, u8 moveIndex);
 void RemoveBattleMonPPBonus(struct BattlePokemon *mon, u8 moveIndex);

--- a/src/data/pokemon/level_up_learnset_pointers.h
+++ b/src/data/pokemon/level_up_learnset_pointers.h
@@ -1,4 +1,4 @@
-const u16 *const gLevelUpLearnsets[NUM_SPECIES] =
+const struct LevelUpMove *const gLevelUpLearnsets[NUM_SPECIES] =
 {
     [SPECIES_NONE] = sBulbasaurLevelUpLearnset,
     [SPECIES_BULBASAUR] = sBulbasaurLevelUpLearnset,

--- a/src/data/pokemon/level_up_learnsets.h
+++ b/src/data/pokemon/level_up_learnsets.h
@@ -1,7 +1,7 @@
-#define LEVEL_UP_MOVE(lvl, move) ((lvl << 9) | move)
-#define LEVEL_UP_END 0xFFFF
+#define LEVEL_UP_MOVE(lvl, moveLearned) {.move = moveLearned, .level = lvl}
+#define LEVEL_UP_END {.move = LEVEL_UP_MOVE_END, .level = 0}
 
-static const u16 sBulbasaurLevelUpLearnset[] = {
+static const struct LevelUpMove sBulbasaurLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(4, MOVE_GROWL),
     LEVEL_UP_MOVE(7, MOVE_LEECH_SEED),
@@ -16,7 +16,7 @@ static const u16 sBulbasaurLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sIvysaurLevelUpLearnset[] = {
+static const struct LevelUpMove sIvysaurLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_LEECH_SEED),
@@ -33,7 +33,7 @@ static const u16 sIvysaurLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sVenusaurLevelUpLearnset[] = {
+static const struct LevelUpMove sVenusaurLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_LEECH_SEED),
@@ -51,7 +51,7 @@ static const u16 sVenusaurLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCharmanderLevelUpLearnset[] = {
+static const struct LevelUpMove sCharmanderLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(5, MOVE_WATER_GUN),
@@ -65,7 +65,7 @@ static const u16 sCharmanderLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCharmeleonLevelUpLearnset[] = {
+static const struct LevelUpMove sCharmeleonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_EMBER),
@@ -80,7 +80,7 @@ static const u16 sCharmeleonLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCharizardLevelUpLearnset[] = {
+static const struct LevelUpMove sCharizardLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_HEAT_WAVE),
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
@@ -98,7 +98,7 @@ static const u16 sCharizardLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSquirtleLevelUpLearnset[] = {
+static const struct LevelUpMove sSquirtleLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(4, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(7, MOVE_BUBBLE),
@@ -113,12 +113,12 @@ static const u16 sSquirtleLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sWartortleLevelUpLearnset[] = {
+static const struct LevelUpMove sWartortleLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_HYPER_BEAM),
     LEVEL_UP_END
 };
 
-static const u16 sBlastoiseLevelUpLearnset[] = {
+static const struct LevelUpMove sBlastoiseLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(1, MOVE_BUBBLE),
@@ -136,19 +136,19 @@ static const u16 sBlastoiseLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCaterpieLevelUpLearnset[] = {
+static const struct LevelUpMove sCaterpieLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_STRING_SHOT),
     LEVEL_UP_END
 };
 
-static const u16 sMetapodLevelUpLearnset[] = {
+static const struct LevelUpMove sMetapodLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(7, MOVE_HARDEN),
     LEVEL_UP_END
 };
 
-static const u16 sButterfreeLevelUpLearnset[] = {
+static const struct LevelUpMove sButterfreeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_CONFUSION),
     LEVEL_UP_MOVE(10, MOVE_CONFUSION),
     LEVEL_UP_MOVE(13, MOVE_POISON_POWDER),
@@ -163,19 +163,19 @@ static const u16 sButterfreeLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sWeedleLevelUpLearnset[] = {
+static const struct LevelUpMove sWeedleLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POISON_STING),
     LEVEL_UP_MOVE(1, MOVE_STRING_SHOT),
     LEVEL_UP_END
 };
 
-static const u16 sKakunaLevelUpLearnset[] = {
+static const struct LevelUpMove sKakunaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(7, MOVE_HARDEN),
     LEVEL_UP_END
 };
 
-static const u16 sBeedrillLevelUpLearnset[] = {
+static const struct LevelUpMove sBeedrillLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_FURY_ATTACK),
     LEVEL_UP_MOVE(10, MOVE_FURY_ATTACK),
     LEVEL_UP_MOVE(15, MOVE_FOCUS_ENERGY),
@@ -188,7 +188,7 @@ static const u16 sBeedrillLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPidgeyLevelUpLearnset[] = {
+static const struct LevelUpMove sPidgeyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(5, MOVE_SAND_ATTACK),
     LEVEL_UP_MOVE(9, MOVE_GUST),
@@ -201,7 +201,7 @@ static const u16 sPidgeyLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPidgeottoLevelUpLearnset[] = {
+static const struct LevelUpMove sPidgeottoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_SAND_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_GUST),
@@ -216,7 +216,7 @@ static const u16 sPidgeottoLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPidgeotLevelUpLearnset[] = {
+static const struct LevelUpMove sPidgeotLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_SAND_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_GUST),
@@ -232,13 +232,13 @@ static const u16 sPidgeotLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sRattataLevelUpLearnset[] = {
+static const struct LevelUpMove sRattataLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_QUICK_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_ENDEAVOR),
     LEVEL_UP_END
 };
 
-static const u16 sRaticateLevelUpLearnset[] = {
+static const struct LevelUpMove sRaticateLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(1, MOVE_QUICK_ATTACK),
@@ -251,7 +251,7 @@ static const u16 sRaticateLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSpearowLevelUpLearnset[] = {
+static const struct LevelUpMove sSpearowLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(7, MOVE_LEER),
@@ -264,7 +264,7 @@ static const u16 sSpearowLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sFearowLevelUpLearnset[] = {
+static const struct LevelUpMove sFearowLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_LEER),
@@ -278,7 +278,7 @@ static const u16 sFearowLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sEkansLevelUpLearnset[] = {
+static const struct LevelUpMove sEkansLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WRAP),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(8, MOVE_POISON_STING),
@@ -293,7 +293,7 @@ static const u16 sEkansLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sArbokLevelUpLearnset[] = {
+static const struct LevelUpMove sArbokLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WRAP),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_POISON_STING),
@@ -310,7 +310,7 @@ static const u16 sArbokLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPikachuLevelUpLearnset[] = {
+static const struct LevelUpMove sPikachuLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_THUNDER_SHOCK),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(6, MOVE_TAIL_WHIP),
@@ -325,7 +325,7 @@ static const u16 sPikachuLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sRaichuLevelUpLearnset[] = {
+static const struct LevelUpMove sRaichuLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_THUNDER_SHOCK),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(1, MOVE_QUICK_ATTACK),
@@ -333,7 +333,7 @@ static const u16 sRaichuLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSandshrewLevelUpLearnset[] = {
+static const struct LevelUpMove sSandshrewLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(6, MOVE_DEFENSE_CURL),
     LEVEL_UP_MOVE(11, MOVE_SAND_ATTACK),
@@ -346,7 +346,7 @@ static const u16 sSandshrewLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSandslashLevelUpLearnset[] = {
+static const struct LevelUpMove sSandslashLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_DEFENSE_CURL),
     LEVEL_UP_MOVE(1, MOVE_SAND_ATTACK),
@@ -361,7 +361,7 @@ static const u16 sSandslashLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sNidoranFLevelUpLearnset[] = {
+static const struct LevelUpMove sNidoranFLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_POISON_STING),
     LEVEL_UP_MOVE(8, MOVE_TAIL_WHIP),
@@ -375,7 +375,7 @@ static const u16 sNidoranFLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sNidorinaLevelUpLearnset[] = {
+static const struct LevelUpMove sNidorinaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(8, MOVE_TAIL_WHIP),
@@ -389,7 +389,7 @@ static const u16 sNidorinaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sNidoqueenLevelUpLearnset[] = {
+static const struct LevelUpMove sNidoqueenLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(1, MOVE_DOUBLE_KICK),
@@ -399,7 +399,7 @@ static const u16 sNidoqueenLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sNidoranMLevelUpLearnset[] = {
+static const struct LevelUpMove sNidoranMLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(8, MOVE_FOCUS_ENERGY),
@@ -413,7 +413,7 @@ static const u16 sNidoranMLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sNidorinoLevelUpLearnset[] = {
+static const struct LevelUpMove sNidorinoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(8, MOVE_FOCUS_ENERGY),
@@ -427,7 +427,7 @@ static const u16 sNidorinoLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sNidokingLevelUpLearnset[] = {
+static const struct LevelUpMove sNidokingLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(1, MOVE_FOCUS_ENERGY),
     LEVEL_UP_MOVE(1, MOVE_DOUBLE_KICK),
@@ -437,7 +437,7 @@ static const u16 sNidokingLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sClefairyLevelUpLearnset[] = {
+static const struct LevelUpMove sClefairyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(5, MOVE_ENCORE),
@@ -454,7 +454,7 @@ static const u16 sClefairyLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sClefableLevelUpLearnset[] = {
+static const struct LevelUpMove sClefableLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SING),
     LEVEL_UP_MOVE(1, MOVE_DOUBLE_SLAP),
     LEVEL_UP_MOVE(1, MOVE_MINIMIZE),
@@ -462,7 +462,7 @@ static const u16 sClefableLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sVulpixLevelUpLearnset[] = {
+static const struct LevelUpMove sVulpixLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_EMBER),
     LEVEL_UP_MOVE(5, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(9, MOVE_ROAR),
@@ -477,7 +477,7 @@ static const u16 sVulpixLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sNinetalesLevelUpLearnset[] = {
+static const struct LevelUpMove sNinetalesLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_EMBER),
     LEVEL_UP_MOVE(1, MOVE_QUICK_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_CONFUSE_RAY),
@@ -486,7 +486,7 @@ static const u16 sNinetalesLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sJigglypuffLevelUpLearnset[] = {
+static const struct LevelUpMove sJigglypuffLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SING),
     LEVEL_UP_MOVE(4, MOVE_DEFENSE_CURL),
     LEVEL_UP_MOVE(9, MOVE_POUND),
@@ -501,7 +501,7 @@ static const u16 sJigglypuffLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sWigglytuffLevelUpLearnset[] = {
+static const struct LevelUpMove sWigglytuffLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SING),
     LEVEL_UP_MOVE(1, MOVE_DISABLE),
     LEVEL_UP_MOVE(1, MOVE_DEFENSE_CURL),
@@ -509,7 +509,7 @@ static const u16 sWigglytuffLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sZubatLevelUpLearnset[] = {
+static const struct LevelUpMove sZubatLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LEECH_LIFE),
     LEVEL_UP_MOVE(6, MOVE_ASTONISH),
     LEVEL_UP_MOVE(11, MOVE_SUPERSONIC),
@@ -523,7 +523,7 @@ static const u16 sZubatLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGolbatLevelUpLearnset[] = {
+static const struct LevelUpMove sGolbatLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCREECH),
     LEVEL_UP_MOVE(1, MOVE_LEECH_LIFE),
     LEVEL_UP_MOVE(1, MOVE_ASTONISH),
@@ -540,7 +540,7 @@ static const u16 sGolbatLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sOddishLevelUpLearnset[] = {
+static const struct LevelUpMove sOddishLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ABSORB),
     LEVEL_UP_MOVE(7, MOVE_SWEET_SCENT),
     LEVEL_UP_MOVE(14, MOVE_POISON_POWDER),
@@ -552,7 +552,7 @@ static const u16 sOddishLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGloomLevelUpLearnset[] = {
+static const struct LevelUpMove sGloomLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ABSORB),
     LEVEL_UP_MOVE(1, MOVE_SWEET_SCENT),
     LEVEL_UP_MOVE(1, MOVE_POISON_POWDER),
@@ -566,7 +566,7 @@ static const u16 sGloomLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sVileplumeLevelUpLearnset[] = {
+static const struct LevelUpMove sVileplumeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ABSORB),
     LEVEL_UP_MOVE(1, MOVE_AROMATHERAPY),
     LEVEL_UP_MOVE(1, MOVE_STUN_SPORE),
@@ -575,7 +575,7 @@ static const u16 sVileplumeLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sParasLevelUpLearnset[] = {
+static const struct LevelUpMove sParasLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(7, MOVE_STUN_SPORE),
     LEVEL_UP_MOVE(13, MOVE_POISON_POWDER),
@@ -588,7 +588,7 @@ static const u16 sParasLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sParasectLevelUpLearnset[] = {
+static const struct LevelUpMove sParasectLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_STUN_SPORE),
     LEVEL_UP_MOVE(1, MOVE_POISON_POWDER),
@@ -603,7 +603,7 @@ static const u16 sParasectLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sVenonatLevelUpLearnset[] = {
+static const struct LevelUpMove sVenonatLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_DISABLE),
     LEVEL_UP_MOVE(1, MOVE_FORESIGHT),
@@ -618,7 +618,7 @@ static const u16 sVenonatLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sVenomothLevelUpLearnset[] = {
+static const struct LevelUpMove sVenomothLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SILVER_WIND),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_DISABLE),
@@ -636,7 +636,7 @@ static const u16 sVenomothLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sDiglettLevelUpLearnset[] = {
+static const struct LevelUpMove sDiglettLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SAND_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(5, MOVE_GROWL),
@@ -650,7 +650,7 @@ static const u16 sDiglettLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sDugtrioLevelUpLearnset[] = {
+static const struct LevelUpMove sDugtrioLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TRI_ATTACK),
 #if defined(FIRERED)
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
@@ -672,7 +672,7 @@ static const u16 sDugtrioLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMeowthLevelUpLearnset[] = {
+static const struct LevelUpMove sMeowthLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(10, MOVE_BITE),
@@ -686,7 +686,7 @@ static const u16 sMeowthLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPersianLevelUpLearnset[] = {
+static const struct LevelUpMove sPersianLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_BITE),
@@ -701,7 +701,7 @@ static const u16 sPersianLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPsyduckLevelUpLearnset[] = {
+static const struct LevelUpMove sPsyduckLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WATER_SPORT),
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(5, MOVE_TAIL_WHIP),
@@ -714,7 +714,7 @@ static const u16 sPsyduckLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGolduckLevelUpLearnset[] = {
+static const struct LevelUpMove sGolduckLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WATER_SPORT),
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
@@ -729,7 +729,7 @@ static const u16 sGolduckLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMankeyLevelUpLearnset[] = {
+static const struct LevelUpMove sMankeyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(6, MOVE_LOW_KICK),
@@ -744,7 +744,7 @@ static const u16 sMankeyLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPrimeapeLevelUpLearnset[] = {
+static const struct LevelUpMove sPrimeapeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_LOW_KICK),
@@ -762,7 +762,7 @@ static const u16 sPrimeapeLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGrowlitheLevelUpLearnset[] = {
+static const struct LevelUpMove sGrowlitheLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BITE),
     LEVEL_UP_MOVE(1, MOVE_ROAR),
     LEVEL_UP_MOVE(7, MOVE_EMBER),
@@ -776,7 +776,7 @@ static const u16 sGrowlitheLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sArcanineLevelUpLearnset[] = {
+static const struct LevelUpMove sArcanineLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BITE),
     LEVEL_UP_MOVE(1, MOVE_ROAR),
     LEVEL_UP_MOVE(1, MOVE_EMBER),
@@ -785,7 +785,7 @@ static const u16 sArcanineLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPoliwagLevelUpLearnset[] = {
+static const struct LevelUpMove sPoliwagLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BUBBLE),
     LEVEL_UP_MOVE(7, MOVE_HYPNOSIS),
     LEVEL_UP_MOVE(13, MOVE_WATER_GUN),
@@ -797,7 +797,7 @@ static const u16 sPoliwagLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPoliwhirlLevelUpLearnset[] = {
+static const struct LevelUpMove sPoliwhirlLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BUBBLE),
     LEVEL_UP_MOVE(1, MOVE_HYPNOSIS),
     LEVEL_UP_MOVE(1, MOVE_WATER_GUN),
@@ -811,7 +811,7 @@ static const u16 sPoliwhirlLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPoliwrathLevelUpLearnset[] = {
+static const struct LevelUpMove sPoliwrathLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WATER_GUN),
     LEVEL_UP_MOVE(1, MOVE_HYPNOSIS),
     LEVEL_UP_MOVE(1, MOVE_DOUBLE_SLAP),
@@ -821,12 +821,12 @@ static const u16 sPoliwrathLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sAbraLevelUpLearnset[] = {
+static const struct LevelUpMove sAbraLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TELEPORT),
     LEVEL_UP_END
 };
 
-static const u16 sKadabraLevelUpLearnset[] = {
+static const struct LevelUpMove sKadabraLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TELEPORT),
     LEVEL_UP_MOVE(1, MOVE_KINESIS),
     LEVEL_UP_MOVE(1, MOVE_CONFUSION),
@@ -842,7 +842,7 @@ static const u16 sKadabraLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sAlakazamLevelUpLearnset[] = {
+static const struct LevelUpMove sAlakazamLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TELEPORT),
     LEVEL_UP_MOVE(1, MOVE_KINESIS),
     LEVEL_UP_MOVE(1, MOVE_CONFUSION),
@@ -858,7 +858,7 @@ static const u16 sAlakazamLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMachopLevelUpLearnset[] = {
+static const struct LevelUpMove sMachopLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LOW_KICK),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(7, MOVE_FOCUS_ENERGY),
@@ -874,7 +874,7 @@ static const u16 sMachopLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMachokeLevelUpLearnset[] = {
+static const struct LevelUpMove sMachokeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LOW_KICK),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_FOCUS_ENERGY),
@@ -891,7 +891,7 @@ static const u16 sMachokeLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMachampLevelUpLearnset[] = {
+static const struct LevelUpMove sMachampLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LOW_KICK),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_FOCUS_ENERGY),
@@ -908,7 +908,7 @@ static const u16 sMachampLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sBellsproutLevelUpLearnset[] = {
+static const struct LevelUpMove sBellsproutLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_VINE_WHIP),
     LEVEL_UP_MOVE(6, MOVE_GROWTH),
     LEVEL_UP_MOVE(11, MOVE_WRAP),
@@ -922,7 +922,7 @@ static const u16 sBellsproutLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sWeepinbellLevelUpLearnset[] = {
+static const struct LevelUpMove sWeepinbellLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_VINE_WHIP),
     LEVEL_UP_MOVE(1, MOVE_GROWTH),
     LEVEL_UP_MOVE(1, MOVE_WRAP),
@@ -938,7 +938,7 @@ static const u16 sWeepinbellLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sVictreebelLevelUpLearnset[] = {
+static const struct LevelUpMove sVictreebelLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_STOCKPILE),
     LEVEL_UP_MOVE(1, MOVE_SPIT_UP),
     LEVEL_UP_MOVE(1, MOVE_SWALLOW),
@@ -949,7 +949,7 @@ static const u16 sVictreebelLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTentacoolLevelUpLearnset[] = {
+static const struct LevelUpMove sTentacoolLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POISON_STING),
     LEVEL_UP_MOVE(6, MOVE_SUPERSONIC),
     LEVEL_UP_MOVE(12, MOVE_CONSTRICT),
@@ -962,7 +962,7 @@ static const u16 sTentacoolLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTentacruelLevelUpLearnset[] = {
+static const struct LevelUpMove sTentacruelLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POISON_STING),
     LEVEL_UP_MOVE(1, MOVE_SUPERSONIC),
     LEVEL_UP_MOVE(1, MOVE_CONSTRICT),
@@ -977,7 +977,7 @@ static const u16 sTentacruelLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGeodudeLevelUpLearnset[] = {
+static const struct LevelUpMove sGeodudeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_DEFENSE_CURL),
     LEVEL_UP_MOVE(6, MOVE_MUD_SPORT),
@@ -992,7 +992,7 @@ static const u16 sGeodudeLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGravelerLevelUpLearnset[] = {
+static const struct LevelUpMove sGravelerLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_DEFENSE_CURL),
     LEVEL_UP_MOVE(1, MOVE_MUD_SPORT),
@@ -1009,7 +1009,7 @@ static const u16 sGravelerLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGolemLevelUpLearnset[] = {
+static const struct LevelUpMove sGolemLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_DEFENSE_CURL),
     LEVEL_UP_MOVE(1, MOVE_MUD_SPORT),
@@ -1026,7 +1026,7 @@ static const u16 sGolemLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPonytaLevelUpLearnset[] = {
+static const struct LevelUpMove sPonytaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_QUICK_ATTACK),
     LEVEL_UP_MOVE(5, MOVE_GROWL),
     LEVEL_UP_MOVE(9, MOVE_TAIL_WHIP),
@@ -1040,7 +1040,7 @@ static const u16 sPonytaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sRapidashLevelUpLearnset[] = {
+static const struct LevelUpMove sRapidashLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_QUICK_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
@@ -1058,7 +1058,7 @@ static const u16 sRapidashLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSlowpokeLevelUpLearnset[] = {
+static const struct LevelUpMove sSlowpokeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_CURSE),
     LEVEL_UP_MOVE(1, MOVE_YAWN),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
@@ -1073,7 +1073,7 @@ static const u16 sSlowpokeLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSlowbroLevelUpLearnset[] = {
+static const struct LevelUpMove sSlowbroLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_CURSE),
     LEVEL_UP_MOVE(1, MOVE_YAWN),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
@@ -1090,7 +1090,7 @@ static const u16 sSlowbroLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMagnemiteLevelUpLearnset[] = {
+static const struct LevelUpMove sMagnemiteLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_METAL_SOUND),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(6, MOVE_THUNDER_SHOCK),
@@ -1105,7 +1105,7 @@ static const u16 sMagnemiteLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMagnetonLevelUpLearnset[] = {
+static const struct LevelUpMove sMagnetonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_METAL_SOUND),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_THUNDER_SHOCK),
@@ -1122,7 +1122,7 @@ static const u16 sMagnetonLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sFarfetchdLevelUpLearnset[] = {
+static const struct LevelUpMove sFarfetchdLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(6, MOVE_SAND_ATTACK),
     LEVEL_UP_MOVE(11, MOVE_LEER),
@@ -1136,7 +1136,7 @@ static const u16 sFarfetchdLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sDoduoLevelUpLearnset[] = {
+static const struct LevelUpMove sDoduoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(9, MOVE_PURSUIT),
@@ -1149,7 +1149,7 @@ static const u16 sDoduoLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sDodrioLevelUpLearnset[] = {
+static const struct LevelUpMove sDodrioLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_PURSUIT),
@@ -1164,7 +1164,7 @@ static const u16 sDodrioLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSeelLevelUpLearnset[] = {
+static const struct LevelUpMove sSeelLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_HEADBUTT),
     LEVEL_UP_MOVE(9, MOVE_GROWL),
     LEVEL_UP_MOVE(17, MOVE_ICY_WIND),
@@ -1176,7 +1176,7 @@ static const u16 sSeelLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sDewgongLevelUpLearnset[] = {
+static const struct LevelUpMove sDewgongLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SIGNAL_BEAM),
     LEVEL_UP_MOVE(1, MOVE_HEADBUTT),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
@@ -1193,7 +1193,7 @@ static const u16 sDewgongLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGrimerLevelUpLearnset[] = {
+static const struct LevelUpMove sGrimerLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POISON_GAS),
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(4, MOVE_HARDEN),
@@ -1207,7 +1207,7 @@ static const u16 sGrimerLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMukLevelUpLearnset[] = {
+static const struct LevelUpMove sMukLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POISON_GAS),
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
@@ -1222,7 +1222,7 @@ static const u16 sMukLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sShellderLevelUpLearnset[] = {
+static const struct LevelUpMove sShellderLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_WITHDRAW),
     LEVEL_UP_MOVE(8, MOVE_ICICLE_SPEAR),
@@ -1235,7 +1235,7 @@ static const u16 sShellderLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCloysterLevelUpLearnset[] = {
+static const struct LevelUpMove sCloysterLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WITHDRAW),
     LEVEL_UP_MOVE(1, MOVE_SUPERSONIC),
     LEVEL_UP_MOVE(1, MOVE_AURORA_BEAM),
@@ -1245,7 +1245,7 @@ static const u16 sCloysterLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGastlyLevelUpLearnset[] = {
+static const struct LevelUpMove sGastlyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_HYPNOSIS),
     LEVEL_UP_MOVE(1, MOVE_LICK),
     LEVEL_UP_MOVE(8, MOVE_SPITE),
@@ -1260,7 +1260,7 @@ static const u16 sGastlyLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sHaunterLevelUpLearnset[] = {
+static const struct LevelUpMove sHaunterLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_HYPNOSIS),
     LEVEL_UP_MOVE(1, MOVE_LICK),
     LEVEL_UP_MOVE(1, MOVE_SPITE),
@@ -1277,7 +1277,7 @@ static const u16 sHaunterLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGengarLevelUpLearnset[] = {
+static const struct LevelUpMove sGengarLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_HYPNOSIS),
     LEVEL_UP_MOVE(1, MOVE_LICK),
     LEVEL_UP_MOVE(1, MOVE_SPITE),
@@ -1294,7 +1294,7 @@ static const u16 sGengarLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sOnixLevelUpLearnset[] = {
+static const struct LevelUpMove sOnixLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_SCREECH),
     LEVEL_UP_MOVE(8, MOVE_BIND),
@@ -1310,7 +1310,7 @@ static const u16 sOnixLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sDrowzeeLevelUpLearnset[] = {
+static const struct LevelUpMove sDrowzeeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(1, MOVE_HYPNOSIS),
     LEVEL_UP_MOVE(7, MOVE_DISABLE),
@@ -1325,7 +1325,7 @@ static const u16 sDrowzeeLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sHypnoLevelUpLearnset[] = {
+static const struct LevelUpMove sHypnoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_NIGHTMARE),
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(1, MOVE_HYPNOSIS),
@@ -1343,7 +1343,7 @@ static const u16 sHypnoLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sKrabbyLevelUpLearnset[] = {
+static const struct LevelUpMove sKrabbyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BUBBLE),
     LEVEL_UP_MOVE(5, MOVE_LEER),
     LEVEL_UP_MOVE(12, MOVE_VICE_GRIP),
@@ -1357,7 +1357,7 @@ static const u16 sKrabbyLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sKinglerLevelUpLearnset[] = {
+static const struct LevelUpMove sKinglerLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_METAL_CLAW),
     LEVEL_UP_MOVE(1, MOVE_BUBBLE),
     LEVEL_UP_MOVE(1, MOVE_LEER),
@@ -1375,7 +1375,7 @@ static const u16 sKinglerLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sVoltorbLevelUpLearnset[] = {
+static const struct LevelUpMove sVoltorbLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_CHARGE),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(8, MOVE_SCREECH),
@@ -1390,7 +1390,7 @@ static const u16 sVoltorbLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sElectrodeLevelUpLearnset[] = {
+static const struct LevelUpMove sElectrodeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_CHARGE),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_SCREECH),
@@ -1407,7 +1407,7 @@ static const u16 sElectrodeLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sExeggcuteLevelUpLearnset[] = {
+static const struct LevelUpMove sExeggcuteLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BARRAGE),
     LEVEL_UP_MOVE(1, MOVE_UPROAR),
     LEVEL_UP_MOVE(1, MOVE_HYPNOSIS),
@@ -1421,7 +1421,7 @@ static const u16 sExeggcuteLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sExeggutorLevelUpLearnset[] = {
+static const struct LevelUpMove sExeggutorLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BARRAGE),
     LEVEL_UP_MOVE(1, MOVE_HYPNOSIS),
     LEVEL_UP_MOVE(1, MOVE_CONFUSION),
@@ -1430,7 +1430,7 @@ static const u16 sExeggutorLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCuboneLevelUpLearnset[] = {
+static const struct LevelUpMove sCuboneLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(5, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(9, MOVE_BONE_CLUB),
@@ -1446,7 +1446,7 @@ static const u16 sCuboneLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMarowakLevelUpLearnset[] = {
+static const struct LevelUpMove sMarowakLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(1, MOVE_BONE_CLUB),
@@ -1465,7 +1465,7 @@ static const u16 sMarowakLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sHitmonleeLevelUpLearnset[] = {
+static const struct LevelUpMove sHitmonleeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_REVENGE),
     LEVEL_UP_MOVE(1, MOVE_DOUBLE_KICK),
     LEVEL_UP_MOVE(6, MOVE_MEDITATE),
@@ -1482,7 +1482,7 @@ static const u16 sHitmonleeLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sHitmonchanLevelUpLearnset[] = {
+static const struct LevelUpMove sHitmonchanLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_REVENGE),
     LEVEL_UP_MOVE(1, MOVE_COMET_PUNCH),
     LEVEL_UP_MOVE(7, MOVE_AGILITY),
@@ -1498,7 +1498,7 @@ static const u16 sHitmonchanLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLickitungLevelUpLearnset[] = {
+static const struct LevelUpMove sLickitungLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LICK),
     LEVEL_UP_MOVE(7, MOVE_SUPERSONIC),
     LEVEL_UP_MOVE(12, MOVE_DEFENSE_CURL),
@@ -1512,7 +1512,7 @@ static const u16 sLickitungLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sKoffingLevelUpLearnset[] = {
+static const struct LevelUpMove sKoffingLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POISON_GAS),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(9, MOVE_SMOG),
@@ -1526,7 +1526,7 @@ static const u16 sKoffingLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sWeezingLevelUpLearnset[] = {
+static const struct LevelUpMove sWeezingLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POISON_GAS),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_SMOG),
@@ -1542,7 +1542,7 @@ static const u16 sWeezingLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sRhyhornLevelUpLearnset[] = {
+static const struct LevelUpMove sRhyhornLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_HORN_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(10, MOVE_STOMP),
@@ -1556,7 +1556,7 @@ static const u16 sRhyhornLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sRhydonLevelUpLearnset[] = {
+static const struct LevelUpMove sRhydonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_HORN_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(1, MOVE_STOMP),
@@ -1572,7 +1572,7 @@ static const u16 sRhydonLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sChanseyLevelUpLearnset[] = {
+static const struct LevelUpMove sChanseyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(5, MOVE_TAIL_WHIP),
@@ -1588,7 +1588,7 @@ static const u16 sChanseyLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTangelaLevelUpLearnset[] = {
+static const struct LevelUpMove sTangelaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_INGRAIN),
     LEVEL_UP_MOVE(1, MOVE_CONSTRICT),
     LEVEL_UP_MOVE(4, MOVE_SLEEP_POWDER),
@@ -1604,7 +1604,7 @@ static const u16 sTangelaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sKangaskhanLevelUpLearnset[] = {
+static const struct LevelUpMove sKangaskhanLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_COMET_PUNCH),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(7, MOVE_BITE),
@@ -1618,7 +1618,7 @@ static const u16 sKangaskhanLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sHorseaLevelUpLearnset[] = {
+static const struct LevelUpMove sHorseaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BUBBLE),
     LEVEL_UP_MOVE(8, MOVE_SMOKESCREEN),
     LEVEL_UP_MOVE(15, MOVE_LEER),
@@ -1630,7 +1630,7 @@ static const u16 sHorseaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSeadraLevelUpLearnset[] = {
+static const struct LevelUpMove sSeadraLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BUBBLE),
     LEVEL_UP_MOVE(1, MOVE_SMOKESCREEN),
     LEVEL_UP_MOVE(1, MOVE_LEER),
@@ -1645,7 +1645,7 @@ static const u16 sSeadraLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGoldeenLevelUpLearnset[] = {
+static const struct LevelUpMove sGoldeenLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(1, MOVE_WATER_SPORT),
@@ -1660,7 +1660,7 @@ static const u16 sGoldeenLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSeakingLevelUpLearnset[] = {
+static const struct LevelUpMove sSeakingLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(1, MOVE_WATER_SPORT),
@@ -1676,7 +1676,7 @@ static const u16 sSeakingLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sStaryuLevelUpLearnset[] = {
+static const struct LevelUpMove sStaryuLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(6, MOVE_WATER_GUN),
@@ -1692,7 +1692,7 @@ static const u16 sStaryuLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sStarmieLevelUpLearnset[] = {
+static const struct LevelUpMove sStarmieLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WATER_GUN),
     LEVEL_UP_MOVE(1, MOVE_RAPID_SPIN),
     LEVEL_UP_MOVE(1, MOVE_RECOVER),
@@ -1701,7 +1701,7 @@ static const u16 sStarmieLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMrMimeLevelUpLearnset[] = {
+static const struct LevelUpMove sMrMimeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BARRIER),
     LEVEL_UP_MOVE(5, MOVE_CONFUSION),
     LEVEL_UP_MOVE(8, MOVE_SUBSTITUTE),
@@ -1721,14 +1721,14 @@ static const u16 sMrMimeLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sScytherLevelUpLearnset[] = {
+static const struct LevelUpMove sScytherLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SLASH),
     LEVEL_UP_MOVE(1, MOVE_SWORDS_DANCE),
     LEVEL_UP_MOVE(1, MOVE_RETREAT),
     LEVEL_UP_END
 };
 
-static const u16 sJynxLevelUpLearnset[] = {
+static const struct LevelUpMove sJynxLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(1, MOVE_LICK),
     LEVEL_UP_MOVE(1, MOVE_LOVELY_KISS),
@@ -1745,7 +1745,7 @@ static const u16 sJynxLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sElectabuzzLevelUpLearnset[] = {
+static const struct LevelUpMove sElectabuzzLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_QUICK_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_THUNDER_PUNCH),
@@ -1758,7 +1758,7 @@ static const u16 sElectabuzzLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMagmarLevelUpLearnset[] = {
+static const struct LevelUpMove sMagmarLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_EMBER),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_SMOG),
@@ -1774,7 +1774,7 @@ static const u16 sMagmarLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPinsirLevelUpLearnset[] = {
+static const struct LevelUpMove sPinsirLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_VICE_GRIP),
     LEVEL_UP_MOVE(1, MOVE_FOCUS_ENERGY),
     LEVEL_UP_MOVE(7, MOVE_BIND),
@@ -1788,7 +1788,7 @@ static const u16 sPinsirLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTaurosLevelUpLearnset[] = {
+static const struct LevelUpMove sTaurosLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(4, MOVE_RAGE),
@@ -1802,14 +1802,14 @@ static const u16 sTaurosLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMagikarpLevelUpLearnset[] = {
+static const struct LevelUpMove sMagikarpLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SPLASH),
     LEVEL_UP_MOVE(15, MOVE_TACKLE),
     LEVEL_UP_MOVE(30, MOVE_FLAIL),
     LEVEL_UP_END
 };
 
-static const u16 sGyaradosLevelUpLearnset[] = {
+static const struct LevelUpMove sGyaradosLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_THRASH),
     LEVEL_UP_MOVE(20, MOVE_BITE),
     LEVEL_UP_MOVE(25, MOVE_DRAGON_RAGE),
@@ -1822,7 +1822,7 @@ static const u16 sGyaradosLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLaprasLevelUpLearnset[] = {
+static const struct LevelUpMove sLaprasLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WATER_GUN),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_SING),
@@ -1838,12 +1838,12 @@ static const u16 sLaprasLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sDittoLevelUpLearnset[] = {
+static const struct LevelUpMove sDittoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TRANSFORM),
     LEVEL_UP_END
 };
 
-static const u16 sEeveeLevelUpLearnset[] = {
+static const struct LevelUpMove sEeveeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(1, MOVE_HELPING_HAND),
@@ -1856,7 +1856,7 @@ static const u16 sEeveeLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sVaporeonLevelUpLearnset[] = {
+static const struct LevelUpMove sVaporeonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(1, MOVE_HELPING_HAND),
@@ -1871,7 +1871,7 @@ static const u16 sVaporeonLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sJolteonLevelUpLearnset[] = {
+static const struct LevelUpMove sJolteonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(1, MOVE_HELPING_HAND),
@@ -1886,7 +1886,7 @@ static const u16 sJolteonLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sFlareonLevelUpLearnset[] = {
+static const struct LevelUpMove sFlareonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(1, MOVE_HELPING_HAND),
@@ -1901,7 +1901,7 @@ static const u16 sFlareonLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPorygonLevelUpLearnset[] = {
+static const struct LevelUpMove sPorygonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_CONVERSION_2),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_CONVERSION),
@@ -1916,7 +1916,7 @@ static const u16 sPorygonLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sOmanyteLevelUpLearnset[] = {
+static const struct LevelUpMove sOmanyteLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_CONSTRICT),
     LEVEL_UP_MOVE(1, MOVE_WITHDRAW),
     LEVEL_UP_MOVE(13, MOVE_BITE),
@@ -1930,7 +1930,7 @@ static const u16 sOmanyteLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sOmastarLevelUpLearnset[] = {
+static const struct LevelUpMove sOmastarLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_CONSTRICT),
     LEVEL_UP_MOVE(1, MOVE_WITHDRAW),
     LEVEL_UP_MOVE(1, MOVE_BITE),
@@ -1947,7 +1947,7 @@ static const u16 sOmastarLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sKabutoLevelUpLearnset[] = {
+static const struct LevelUpMove sKabutoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(13, MOVE_ABSORB),
@@ -1961,7 +1961,7 @@ static const u16 sKabutoLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sKabutopsLevelUpLearnset[] = {
+static const struct LevelUpMove sKabutopsLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_FURY_CUTTER),
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
@@ -1979,7 +1979,7 @@ static const u16 sKabutopsLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sAerodactylLevelUpLearnset[] = {
+static const struct LevelUpMove sAerodactylLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WING_ATTACK),
     LEVEL_UP_MOVE(8, MOVE_AGILITY),
     LEVEL_UP_MOVE(15, MOVE_BITE),
@@ -1991,7 +1991,7 @@ static const u16 sAerodactylLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSnorlaxLevelUpLearnset[] = {
+static const struct LevelUpMove sSnorlaxLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(5, MOVE_AMNESIA),
     LEVEL_UP_MOVE(9, MOVE_DEFENSE_CURL),
@@ -2009,7 +2009,7 @@ static const u16 sSnorlaxLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sArticunoLevelUpLearnset[] = {
+static const struct LevelUpMove sArticunoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GUST),
     LEVEL_UP_MOVE(1, MOVE_POWDER_SNOW),
     LEVEL_UP_MOVE(13, MOVE_MIST),
@@ -2022,7 +2022,7 @@ static const u16 sArticunoLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sZapdosLevelUpLearnset[] = {
+static const struct LevelUpMove sZapdosLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(1, MOVE_THUNDER_SHOCK),
     LEVEL_UP_MOVE(13, MOVE_THUNDER_WAVE),
@@ -2035,7 +2035,7 @@ static const u16 sZapdosLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMoltresLevelUpLearnset[] = {
+static const struct LevelUpMove sMoltresLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WING_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_EMBER),
     LEVEL_UP_MOVE(13, MOVE_FIRE_SPIN),
@@ -2048,7 +2048,7 @@ static const u16 sMoltresLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sDratiniLevelUpLearnset[] = {
+static const struct LevelUpMove sDratiniLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WRAP),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(8, MOVE_THUNDER_WAVE),
@@ -2062,7 +2062,7 @@ static const u16 sDratiniLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sDragonairLevelUpLearnset[] = {
+static const struct LevelUpMove sDragonairLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WRAP),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_THUNDER_WAVE),
@@ -2078,7 +2078,7 @@ static const u16 sDragonairLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sDragoniteLevelUpLearnset[] = {
+static const struct LevelUpMove sDragoniteLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WRAP),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_THUNDER_WAVE),
@@ -2095,7 +2095,7 @@ static const u16 sDragoniteLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMewtwoLevelUpLearnset[] = {
+static const struct LevelUpMove sMewtwoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_CONFUSION),
     LEVEL_UP_MOVE(1, MOVE_DISABLE),
     LEVEL_UP_MOVE(11, MOVE_BARRIER),
@@ -2110,7 +2110,7 @@ static const u16 sMewtwoLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMewLevelUpLearnset[] = {
+static const struct LevelUpMove sMewLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(10, MOVE_TRANSFORM),
     LEVEL_UP_MOVE(20, MOVE_MEGA_PUNCH),
@@ -2120,7 +2120,7 @@ static const u16 sMewLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sChikoritaLevelUpLearnset[] = {
+static const struct LevelUpMove sChikoritaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(8, MOVE_RAZOR_LEAF),
@@ -2134,7 +2134,7 @@ static const u16 sChikoritaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sBayleefLevelUpLearnset[] = {
+static const struct LevelUpMove sBayleefLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_RAZOR_LEAF),
@@ -2150,7 +2150,7 @@ static const u16 sBayleefLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMeganiumLevelUpLearnset[] = {
+static const struct LevelUpMove sMeganiumLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_RAZOR_LEAF),
@@ -2166,7 +2166,7 @@ static const u16 sMeganiumLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCyndaquilLevelUpLearnset[] = {
+static const struct LevelUpMove sCyndaquilLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(6, MOVE_SMOKESCREEN),
@@ -2178,7 +2178,7 @@ static const u16 sCyndaquilLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sQuilavaLevelUpLearnset[] = {
+static const struct LevelUpMove sQuilavaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_SMOKESCREEN),
@@ -2191,7 +2191,7 @@ static const u16 sQuilavaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTyphlosionLevelUpLearnset[] = {
+static const struct LevelUpMove sTyphlosionLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_SMOKESCREEN),
@@ -2205,7 +2205,7 @@ static const u16 sTyphlosionLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTotodileLevelUpLearnset[] = {
+static const struct LevelUpMove sTotodileLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(7, MOVE_RAGE),
@@ -2218,7 +2218,7 @@ static const u16 sTotodileLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCroconawLevelUpLearnset[] = {
+static const struct LevelUpMove sCroconawLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_RAGE),
@@ -2232,7 +2232,7 @@ static const u16 sCroconawLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sFeraligatrLevelUpLearnset[] = {
+static const struct LevelUpMove sFeraligatrLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_RAGE),
@@ -2247,7 +2247,7 @@ static const u16 sFeraligatrLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSentretLevelUpLearnset[] = {
+static const struct LevelUpMove sSentretLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(4, MOVE_DEFENSE_CURL),
     LEVEL_UP_MOVE(7, MOVE_QUICK_ATTACK),
@@ -2260,7 +2260,7 @@ static const u16 sSentretLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sFurretLevelUpLearnset[] = {
+static const struct LevelUpMove sFurretLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_DEFENSE_CURL),
     LEVEL_UP_MOVE(1, MOVE_QUICK_ATTACK),
@@ -2275,7 +2275,7 @@ static const u16 sFurretLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sHoothootLevelUpLearnset[] = {
+static const struct LevelUpMove sHoothootLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(6, MOVE_FORESIGHT),
@@ -2288,7 +2288,7 @@ static const u16 sHoothootLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sNoctowlLevelUpLearnset[] = {
+static const struct LevelUpMove sNoctowlLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_FORESIGHT),
@@ -2303,7 +2303,7 @@ static const u16 sNoctowlLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLedybaLevelUpLearnset[] = {
+static const struct LevelUpMove sLedybaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(8, MOVE_SUPERSONIC),
     LEVEL_UP_MOVE(15, MOVE_COMET_PUNCH),
@@ -2317,7 +2317,7 @@ static const u16 sLedybaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLedianLevelUpLearnset[] = {
+static const struct LevelUpMove sLedianLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_SUPERSONIC),
     LEVEL_UP_MOVE(8, MOVE_SUPERSONIC),
@@ -2332,7 +2332,7 @@ static const u16 sLedianLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSpinarakLevelUpLearnset[] = {
+static const struct LevelUpMove sSpinarakLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POISON_STING),
     LEVEL_UP_MOVE(1, MOVE_STRING_SHOT),
     LEVEL_UP_MOVE(6, MOVE_SCARY_FACE),
@@ -2346,7 +2346,7 @@ static const u16 sSpinarakLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sAriadosLevelUpLearnset[] = {
+static const struct LevelUpMove sAriadosLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POISON_STING),
     LEVEL_UP_MOVE(1, MOVE_STRING_SHOT),
     LEVEL_UP_MOVE(1, MOVE_SCARY_FACE),
@@ -2362,7 +2362,7 @@ static const u16 sAriadosLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCrobatLevelUpLearnset[] = {
+static const struct LevelUpMove sCrobatLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCREECH),
     LEVEL_UP_MOVE(1, MOVE_LEECH_LIFE),
     LEVEL_UP_MOVE(1, MOVE_ASTONISH),
@@ -2379,7 +2379,7 @@ static const u16 sCrobatLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sChinchouLevelUpLearnset[] = {
+static const struct LevelUpMove sChinchouLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BUBBLE),
     LEVEL_UP_MOVE(1, MOVE_THUNDER_WAVE),
     LEVEL_UP_MOVE(5, MOVE_SUPERSONIC),
@@ -2393,7 +2393,7 @@ static const u16 sChinchouLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLanturnLevelUpLearnset[] = {
+static const struct LevelUpMove sLanturnLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BUBBLE),
     LEVEL_UP_MOVE(1, MOVE_THUNDER_WAVE),
     LEVEL_UP_MOVE(1, MOVE_SUPERSONIC),
@@ -2408,7 +2408,7 @@ static const u16 sLanturnLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPichuLevelUpLearnset[] = {
+static const struct LevelUpMove sPichuLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_THUNDER_SHOCK),
     LEVEL_UP_MOVE(1, MOVE_CHARM),
     LEVEL_UP_MOVE(6, MOVE_TAIL_WHIP),
@@ -2417,7 +2417,7 @@ static const u16 sPichuLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCleffaLevelUpLearnset[] = {
+static const struct LevelUpMove sCleffaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(1, MOVE_CHARM),
     LEVEL_UP_MOVE(4, MOVE_ENCORE),
@@ -2427,7 +2427,7 @@ static const u16 sCleffaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sIgglybuffLevelUpLearnset[] = {
+static const struct LevelUpMove sIgglybuffLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SING),
     LEVEL_UP_MOVE(1, MOVE_CHARM),
     LEVEL_UP_MOVE(4, MOVE_DEFENSE_CURL),
@@ -2436,7 +2436,7 @@ static const u16 sIgglybuffLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTogepiLevelUpLearnset[] = {
+static const struct LevelUpMove sTogepiLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_CHARM),
     LEVEL_UP_MOVE(4, MOVE_METRONOME),
@@ -2452,7 +2452,7 @@ static const u16 sTogepiLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTogeticLevelUpLearnset[] = {
+static const struct LevelUpMove sTogeticLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_MAGICAL_LEAF),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_CHARM),
@@ -2471,7 +2471,7 @@ static const u16 sTogeticLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sNatuLevelUpLearnset[] = {
+static const struct LevelUpMove sNatuLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(10, MOVE_NIGHT_SHADE),
@@ -2483,7 +2483,7 @@ static const u16 sNatuLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sXatuLevelUpLearnset[] = {
+static const struct LevelUpMove sXatuLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(10, MOVE_NIGHT_SHADE),
@@ -2495,7 +2495,7 @@ static const u16 sXatuLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMareepLevelUpLearnset[] = {
+static const struct LevelUpMove sMareepLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(9, MOVE_THUNDER_SHOCK),
@@ -2506,7 +2506,7 @@ static const u16 sMareepLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sFlaaffyLevelUpLearnset[] = {
+static const struct LevelUpMove sFlaaffyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_THUNDER_SHOCK),
@@ -2518,7 +2518,7 @@ static const u16 sFlaaffyLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sAmpharosLevelUpLearnset[] = {
+static const struct LevelUpMove sAmpharosLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_THUNDER_SHOCK),
@@ -2532,7 +2532,7 @@ static const u16 sAmpharosLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sBellossomLevelUpLearnset[] = {
+static const struct LevelUpMove sBellossomLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ABSORB),
     LEVEL_UP_MOVE(1, MOVE_SWEET_SCENT),
     LEVEL_UP_MOVE(1, MOVE_STUN_SPORE),
@@ -2542,7 +2542,7 @@ static const u16 sBellossomLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMarillLevelUpLearnset[] = {
+static const struct LevelUpMove sMarillLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(3, MOVE_DEFENSE_CURL),
     LEVEL_UP_MOVE(6, MOVE_TAIL_WHIP),
@@ -2555,7 +2555,7 @@ static const u16 sMarillLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sAzumarillLevelUpLearnset[] = {
+static const struct LevelUpMove sAzumarillLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_DEFENSE_CURL),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
@@ -2571,7 +2571,7 @@ static const u16 sAzumarillLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSudowoodoLevelUpLearnset[] = {
+static const struct LevelUpMove sSudowoodoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ROCK_THROW),
     LEVEL_UP_MOVE(1, MOVE_MIMIC),
     LEVEL_UP_MOVE(9, MOVE_FLAIL),
@@ -2584,7 +2584,7 @@ static const u16 sSudowoodoLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPolitoedLevelUpLearnset[] = {
+static const struct LevelUpMove sPolitoedLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WATER_GUN),
     LEVEL_UP_MOVE(1, MOVE_HYPNOSIS),
     LEVEL_UP_MOVE(1, MOVE_DOUBLE_SLAP),
@@ -2594,7 +2594,7 @@ static const u16 sPolitoedLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sHoppipLevelUpLearnset[] = {
+static const struct LevelUpMove sHoppipLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SPLASH),
     LEVEL_UP_MOVE(5, MOVE_SYNTHESIS),
     LEVEL_UP_MOVE(5, MOVE_TAIL_WHIP),
@@ -2608,7 +2608,7 @@ static const u16 sHoppipLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSkiploomLevelUpLearnset[] = {
+static const struct LevelUpMove sSkiploomLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SPLASH),
     LEVEL_UP_MOVE(1, MOVE_SYNTHESIS),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
@@ -2625,7 +2625,7 @@ static const u16 sSkiploomLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sJumpluffLevelUpLearnset[] = {
+static const struct LevelUpMove sJumpluffLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SPLASH),
     LEVEL_UP_MOVE(1, MOVE_SYNTHESIS),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
@@ -2642,7 +2642,7 @@ static const u16 sJumpluffLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sAipomLevelUpLearnset[] = {
+static const struct LevelUpMove sAipomLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(6, MOVE_SAND_ATTACK),
@@ -2656,7 +2656,7 @@ static const u16 sAipomLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSunkernLevelUpLearnset[] = {
+static const struct LevelUpMove sSunkernLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ABSORB),
     LEVEL_UP_MOVE(6, MOVE_GROWTH),
     LEVEL_UP_MOVE(13, MOVE_MEGA_DRAIN),
@@ -2668,7 +2668,7 @@ static const u16 sSunkernLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSunfloraLevelUpLearnset[] = {
+static const struct LevelUpMove sSunfloraLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ABSORB),
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(6, MOVE_GROWTH),
@@ -2681,7 +2681,7 @@ static const u16 sSunfloraLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sYanmaLevelUpLearnset[] = {
+static const struct LevelUpMove sYanmaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_FORESIGHT),
     LEVEL_UP_MOVE(6, MOVE_QUICK_ATTACK),
@@ -2696,7 +2696,7 @@ static const u16 sYanmaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sWooperLevelUpLearnset[] = {
+static const struct LevelUpMove sWooperLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WATER_GUN),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(11, MOVE_SLAM),
@@ -2710,7 +2710,7 @@ static const u16 sWooperLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sQuagsireLevelUpLearnset[] = {
+static const struct LevelUpMove sQuagsireLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WATER_GUN),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(11, MOVE_SLAM),
@@ -2724,7 +2724,7 @@ static const u16 sQuagsireLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sEspeonLevelUpLearnset[] = {
+static const struct LevelUpMove sEspeonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(1, MOVE_HELPING_HAND),
@@ -2739,7 +2739,7 @@ static const u16 sEspeonLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sUmbreonLevelUpLearnset[] = {
+static const struct LevelUpMove sUmbreonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(1, MOVE_HELPING_HAND),
@@ -2754,7 +2754,7 @@ static const u16 sUmbreonLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMurkrowLevelUpLearnset[] = {
+static const struct LevelUpMove sMurkrowLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(9, MOVE_ASTONISH),
     LEVEL_UP_MOVE(14, MOVE_PURSUIT),
@@ -2766,7 +2766,7 @@ static const u16 sMurkrowLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSlowkingLevelUpLearnset[] = {
+static const struct LevelUpMove sSlowkingLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_CURSE),
     LEVEL_UP_MOVE(1, MOVE_YAWN),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
@@ -2781,7 +2781,7 @@ static const u16 sSlowkingLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMisdreavusLevelUpLearnset[] = {
+static const struct LevelUpMove sMisdreavusLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_PSYWAVE),
     LEVEL_UP_MOVE(6, MOVE_SPITE),
@@ -2795,12 +2795,12 @@ static const u16 sMisdreavusLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sUnownLevelUpLearnset[] = {
+static const struct LevelUpMove sUnownLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_HIDDEN_POWER),
     LEVEL_UP_END
 };
 
-static const u16 sWobbuffetLevelUpLearnset[] = {
+static const struct LevelUpMove sWobbuffetLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_COUNTER),
     LEVEL_UP_MOVE(1, MOVE_MIRROR_COAT),
     LEVEL_UP_MOVE(1, MOVE_SAFEGUARD),
@@ -2808,7 +2808,7 @@ static const u16 sWobbuffetLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGirafarigLevelUpLearnset[] = {
+static const struct LevelUpMove sGirafarigLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(7, MOVE_ASTONISH),
@@ -2822,7 +2822,7 @@ static const u16 sGirafarigLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPinecoLevelUpLearnset[] = {
+static const struct LevelUpMove sPinecoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_PROTECT),
     LEVEL_UP_MOVE(8, MOVE_SELF_DESTRUCT),
@@ -2835,7 +2835,7 @@ static const u16 sPinecoLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sForretressLevelUpLearnset[] = {
+static const struct LevelUpMove sForretressLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_PROTECT),
     LEVEL_UP_MOVE(1, MOVE_SELF_DESTRUCT),
@@ -2850,7 +2850,7 @@ static const u16 sForretressLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sDunsparceLevelUpLearnset[] = {
+static const struct LevelUpMove sDunsparceLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_RAGE),
     LEVEL_UP_MOVE(4, MOVE_DEFENSE_CURL),
     LEVEL_UP_MOVE(11, MOVE_YAWN),
@@ -2865,7 +2865,7 @@ static const u16 sDunsparceLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGligarLevelUpLearnset[] = {
+static const struct LevelUpMove sGligarLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POISON_STING),
     LEVEL_UP_MOVE(6, MOVE_SAND_ATTACK),
     LEVEL_UP_MOVE(13, MOVE_HARDEN),
@@ -2877,7 +2877,7 @@ static const u16 sGligarLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSteelixLevelUpLearnset[] = {
+static const struct LevelUpMove sSteelixLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_SCREECH),
     LEVEL_UP_MOVE(8, MOVE_BIND),
@@ -2893,7 +2893,7 @@ static const u16 sSteelixLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSnubbullLevelUpLearnset[] = {
+static const struct LevelUpMove sSnubbullLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_SCARY_FACE),
     LEVEL_UP_MOVE(4, MOVE_TAIL_WHIP),
@@ -2907,7 +2907,7 @@ static const u16 sSnubbullLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGranbullLevelUpLearnset[] = {
+static const struct LevelUpMove sGranbullLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_SCARY_FACE),
     LEVEL_UP_MOVE(4, MOVE_TAIL_WHIP),
@@ -2921,7 +2921,7 @@ static const u16 sGranbullLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sQwilfishLevelUpLearnset[] = {
+static const struct LevelUpMove sQwilfishLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SPIKES),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_POISON_STING),
@@ -2936,7 +2936,7 @@ static const u16 sQwilfishLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sScizorLevelUpLearnset[] = {
+static const struct LevelUpMove sScizorLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_QUICK_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(6, MOVE_FOCUS_ENERGY),
@@ -2951,7 +2951,7 @@ static const u16 sScizorLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sShuckleLevelUpLearnset[] = {
+static const struct LevelUpMove sShuckleLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_CONSTRICT),
     LEVEL_UP_MOVE(1, MOVE_WITHDRAW),
     LEVEL_UP_MOVE(9, MOVE_WRAP),
@@ -2962,7 +2962,7 @@ static const u16 sShuckleLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sHeracrossLevelUpLearnset[] = {
+static const struct LevelUpMove sHeracrossLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(6, MOVE_HORN_ATTACK),
@@ -2976,7 +2976,7 @@ static const u16 sHeracrossLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSneaselLevelUpLearnset[] = {
+static const struct LevelUpMove sSneaselLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_TAUNT),
@@ -2992,7 +2992,7 @@ static const u16 sSneaselLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTeddiursaLevelUpLearnset[] = {
+static const struct LevelUpMove sTeddiursaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(7, MOVE_LICK),
@@ -3006,7 +3006,7 @@ static const u16 sTeddiursaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sUrsaringLevelUpLearnset[] = {
+static const struct LevelUpMove sUrsaringLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_LICK),
@@ -3022,7 +3022,7 @@ static const u16 sUrsaringLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSlugmaLevelUpLearnset[] = {
+static const struct LevelUpMove sSlugmaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_YAWN),
     LEVEL_UP_MOVE(1, MOVE_SMOG),
     LEVEL_UP_MOVE(8, MOVE_EMBER),
@@ -3035,7 +3035,7 @@ static const u16 sSlugmaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMagcargoLevelUpLearnset[] = {
+static const struct LevelUpMove sMagcargoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_YAWN),
     LEVEL_UP_MOVE(1, MOVE_SMOG),
     LEVEL_UP_MOVE(1, MOVE_EMBER),
@@ -3050,7 +3050,7 @@ static const u16 sMagcargoLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSwinubLevelUpLearnset[] = {
+static const struct LevelUpMove sSwinubLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_ODOR_SLEUTH),
     LEVEL_UP_MOVE(10, MOVE_POWDER_SNOW),
@@ -3062,7 +3062,7 @@ static const u16 sSwinubLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPiloswineLevelUpLearnset[] = {
+static const struct LevelUpMove sPiloswineLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_HORN_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_ODOR_SLEUTH),
     LEVEL_UP_MOVE(1, MOVE_POWDER_SNOW),
@@ -3077,7 +3077,7 @@ static const u16 sPiloswineLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCorsolaLevelUpLearnset[] = {
+static const struct LevelUpMove sCorsolaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(6, MOVE_HARDEN),
     LEVEL_UP_MOVE(12, MOVE_BUBBLE),
@@ -3091,7 +3091,7 @@ static const u16 sCorsolaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sRemoraidLevelUpLearnset[] = {
+static const struct LevelUpMove sRemoraidLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WATER_GUN),
     LEVEL_UP_MOVE(11, MOVE_LOCK_ON),
     LEVEL_UP_MOVE(22, MOVE_PSYBEAM),
@@ -3103,7 +3103,7 @@ static const u16 sRemoraidLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sOctilleryLevelUpLearnset[] = {
+static const struct LevelUpMove sOctilleryLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WATER_GUN),
     LEVEL_UP_MOVE(11, MOVE_CONSTRICT),
     LEVEL_UP_MOVE(22, MOVE_PSYBEAM),
@@ -3116,12 +3116,12 @@ static const u16 sOctilleryLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sDelibirdLevelUpLearnset[] = {
+static const struct LevelUpMove sDelibirdLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PRESENT),
     LEVEL_UP_END
 };
 
-static const u16 sMantineLevelUpLearnset[] = {
+static const struct LevelUpMove sMantineLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_BUBBLE),
     LEVEL_UP_MOVE(8, MOVE_SUPERSONIC),
@@ -3134,7 +3134,7 @@ static const u16 sMantineLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSkarmoryLevelUpLearnset[] = {
+static const struct LevelUpMove sSkarmoryLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(10, MOVE_SAND_ATTACK),
@@ -3148,7 +3148,7 @@ static const u16 sSkarmoryLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sHoundourLevelUpLearnset[] = {
+static const struct LevelUpMove sHoundourLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_EMBER),
     LEVEL_UP_MOVE(7, MOVE_HOWL),
@@ -3162,7 +3162,7 @@ static const u16 sHoundourLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sHoundoomLevelUpLearnset[] = {
+static const struct LevelUpMove sHoundoomLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_EMBER),
     LEVEL_UP_MOVE(1, MOVE_HOWL),
@@ -3177,7 +3177,7 @@ static const u16 sHoundoomLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sKingdraLevelUpLearnset[] = {
+static const struct LevelUpMove sKingdraLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BUBBLE),
     LEVEL_UP_MOVE(1, MOVE_SMOKESCREEN),
     LEVEL_UP_MOVE(1, MOVE_LEER),
@@ -3192,7 +3192,7 @@ static const u16 sKingdraLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPhanpyLevelUpLearnset[] = {
+static const struct LevelUpMove sPhanpyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ODOR_SLEUTH),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
@@ -3205,7 +3205,7 @@ static const u16 sPhanpyLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sDonphanLevelUpLearnset[] = {
+static const struct LevelUpMove sDonphanLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ODOR_SLEUTH),
     LEVEL_UP_MOVE(1, MOVE_HORN_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
@@ -3218,7 +3218,7 @@ static const u16 sDonphanLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPorygon2LevelUpLearnset[] = {
+static const struct LevelUpMove sPorygon2LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_CONVERSION_2),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_CONVERSION),
@@ -3233,7 +3233,7 @@ static const u16 sPorygon2LevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sStantlerLevelUpLearnset[] = {
+static const struct LevelUpMove sStantlerLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(7, MOVE_LEER),
     LEVEL_UP_MOVE(11, MOVE_ASTONISH),
@@ -3247,7 +3247,7 @@ static const u16 sStantlerLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSmeargleLevelUpLearnset[] = {
+static const struct LevelUpMove sSmeargleLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SKETCH),
     LEVEL_UP_MOVE(11, MOVE_SKETCH),
     LEVEL_UP_MOVE(21, MOVE_SKETCH),
@@ -3261,12 +3261,12 @@ static const u16 sSmeargleLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTyrogueLevelUpLearnset[] = {
+static const struct LevelUpMove sTyrogueLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sHitmontopLevelUpLearnset[] = {
+static const struct LevelUpMove sHitmontopLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_REVENGE),
     LEVEL_UP_MOVE(1, MOVE_ROLLING_KICK),
     LEVEL_UP_MOVE(7, MOVE_FOCUS_ENERGY),
@@ -3281,7 +3281,7 @@ static const u16 sHitmontopLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSmoochumLevelUpLearnset[] = {
+static const struct LevelUpMove sSmoochumLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(1, MOVE_LICK),
     LEVEL_UP_MOVE(9, MOVE_SWEET_KISS),
@@ -3296,7 +3296,7 @@ static const u16 sSmoochumLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sElekidLevelUpLearnset[] = {
+static const struct LevelUpMove sElekidLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_QUICK_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(9, MOVE_THUNDER_PUNCH),
@@ -3308,7 +3308,7 @@ static const u16 sElekidLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMagbyLevelUpLearnset[] = {
+static const struct LevelUpMove sMagbyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_EMBER),
     LEVEL_UP_MOVE(7, MOVE_LEER),
     LEVEL_UP_MOVE(13, MOVE_SMOG),
@@ -3321,7 +3321,7 @@ static const u16 sMagbyLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMiltankLevelUpLearnset[] = {
+static const struct LevelUpMove sMiltankLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(4, MOVE_GROWL),
     LEVEL_UP_MOVE(8, MOVE_DEFENSE_CURL),
@@ -3334,7 +3334,7 @@ static const u16 sMiltankLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sBlisseyLevelUpLearnset[] = {
+static const struct LevelUpMove sBlisseyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(4, MOVE_TAIL_WHIP),
@@ -3350,7 +3350,7 @@ static const u16 sBlisseyLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sRaikouLevelUpLearnset[] = {
+static const struct LevelUpMove sRaikouLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BITE),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(11, MOVE_THUNDER_SHOCK),
@@ -3364,7 +3364,7 @@ static const u16 sRaikouLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sEnteiLevelUpLearnset[] = {
+static const struct LevelUpMove sEnteiLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BITE),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(11, MOVE_EMBER),
@@ -3378,7 +3378,7 @@ static const u16 sEnteiLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSuicuneLevelUpLearnset[] = {
+static const struct LevelUpMove sSuicuneLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BITE),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(11, MOVE_BUBBLE_BEAM),
@@ -3392,7 +3392,7 @@ static const u16 sSuicuneLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLarvitarLevelUpLearnset[] = {
+static const struct LevelUpMove sLarvitarLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BITE),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(8, MOVE_SANDSTORM),
@@ -3406,7 +3406,7 @@ static const u16 sLarvitarLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPupitarLevelUpLearnset[] = {
+static const struct LevelUpMove sPupitarLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BITE),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_SANDSTORM),
@@ -3422,7 +3422,7 @@ static const u16 sPupitarLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTyranitarLevelUpLearnset[] = {
+static const struct LevelUpMove sTyranitarLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BITE),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_SANDSTORM),
@@ -3438,7 +3438,7 @@ static const u16 sTyranitarLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLugiaLevelUpLearnset[] = {
+static const struct LevelUpMove sLugiaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WHIRLWIND),
     LEVEL_UP_MOVE(11, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(22, MOVE_GUST),
@@ -3452,7 +3452,7 @@ static const u16 sLugiaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sHoOhLevelUpLearnset[] = {
+static const struct LevelUpMove sHoOhLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WHIRLWIND),
     LEVEL_UP_MOVE(11, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(22, MOVE_GUST),
@@ -3466,7 +3466,7 @@ static const u16 sHoOhLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCelebiLevelUpLearnset[] = {
+static const struct LevelUpMove sCelebiLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LEECH_SEED),
     LEVEL_UP_MOVE(1, MOVE_CONFUSION),
     LEVEL_UP_MOVE(1, MOVE_RECOVER),
@@ -3479,132 +3479,132 @@ static const u16 sCelebiLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSpecies252LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies252LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies253LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies253LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies254LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies254LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies255LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies255LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies256LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies256LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies257LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies257LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies258LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies258LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies259LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies259LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies260LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies260LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies261LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies261LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies262LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies262LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies263LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies263LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies264LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies264LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies265LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies265LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies266LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies266LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies267LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies267LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies268LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies268LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies269LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies269LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies270LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies270LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies271LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies271LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies272LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies272LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies273LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies273LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies274LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies274LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies275LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies275LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sSpecies276LevelUpLearnset[] = {
+static const struct LevelUpMove sSpecies276LevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_END
 };
 
-static const u16 sTreeckoLevelUpLearnset[] = {
+static const struct LevelUpMove sTreeckoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(6, MOVE_ABSORB),
@@ -3619,7 +3619,7 @@ static const u16 sTreeckoLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGrovyleLevelUpLearnset[] = {
+static const struct LevelUpMove sGrovyleLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_ABSORB),
@@ -3637,7 +3637,7 @@ static const u16 sGrovyleLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSceptileLevelUpLearnset[] = {
+static const struct LevelUpMove sSceptileLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_ABSORB),
@@ -3655,7 +3655,7 @@ static const u16 sSceptileLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTorchicLevelUpLearnset[] = {
+static const struct LevelUpMove sTorchicLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(7, MOVE_FOCUS_ENERGY),
@@ -3670,7 +3670,7 @@ static const u16 sTorchicLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCombuskenLevelUpLearnset[] = {
+static const struct LevelUpMove sCombuskenLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_FOCUS_ENERGY),
@@ -3688,7 +3688,7 @@ static const u16 sCombuskenLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sBlazikenLevelUpLearnset[] = {
+static const struct LevelUpMove sBlazikenLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_FIRE_PUNCH),
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
@@ -3708,7 +3708,7 @@ static const u16 sBlazikenLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMudkipLevelUpLearnset[] = {
+static const struct LevelUpMove sMudkipLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(6, MOVE_MUD_SLAP),
@@ -3724,7 +3724,7 @@ static const u16 sMudkipLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMarshtompLevelUpLearnset[] = {
+static const struct LevelUpMove sMarshtompLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_MUD_SLAP),
@@ -3743,7 +3743,7 @@ static const u16 sMarshtompLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSwampertLevelUpLearnset[] = {
+static const struct LevelUpMove sSwampertLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_MUD_SLAP),
@@ -3762,7 +3762,7 @@ static const u16 sSwampertLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPoochyenaLevelUpLearnset[] = {
+static const struct LevelUpMove sPoochyenaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(5, MOVE_HOWL),
     LEVEL_UP_MOVE(9, MOVE_SAND_ATTACK),
@@ -3778,7 +3778,7 @@ static const u16 sPoochyenaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMightyenaLevelUpLearnset[] = {
+static const struct LevelUpMove sMightyenaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_HOWL),
     LEVEL_UP_MOVE(1, MOVE_SAND_ATTACK),
@@ -3797,7 +3797,7 @@ static const u16 sMightyenaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sZigzagoonLevelUpLearnset[] = {
+static const struct LevelUpMove sZigzagoonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(5, MOVE_TAIL_WHIP),
@@ -3813,7 +3813,7 @@ static const u16 sZigzagoonLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLinooneLevelUpLearnset[] = {
+static const struct LevelUpMove sLinooneLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
@@ -3831,20 +3831,20 @@ static const u16 sLinooneLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sWurmpleLevelUpLearnset[] = {
+static const struct LevelUpMove sWurmpleLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_STRING_SHOT),
     LEVEL_UP_MOVE(5, MOVE_POISON_STING),
     LEVEL_UP_END
 };
 
-static const u16 sSilcoonLevelUpLearnset[] = {
+static const struct LevelUpMove sSilcoonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(7, MOVE_HARDEN),
     LEVEL_UP_END
 };
 
-static const u16 sBeautiflyLevelUpLearnset[] = {
+static const struct LevelUpMove sBeautiflyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ABSORB),
     LEVEL_UP_MOVE(10, MOVE_ABSORB),
     LEVEL_UP_MOVE(13, MOVE_GUST),
@@ -3858,13 +3858,13 @@ static const u16 sBeautiflyLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCascoonLevelUpLearnset[] = {
+static const struct LevelUpMove sCascoonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(7, MOVE_HARDEN),
     LEVEL_UP_END
 };
 
-static const u16 sDustoxLevelUpLearnset[] = {
+static const struct LevelUpMove sDustoxLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_CONFUSION),
     LEVEL_UP_MOVE(10, MOVE_CONFUSION),
     LEVEL_UP_MOVE(13, MOVE_GUST),
@@ -3878,7 +3878,7 @@ static const u16 sDustoxLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLotadLevelUpLearnset[] = {
+static const struct LevelUpMove sLotadLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ASTONISH),
     LEVEL_UP_MOVE(3, MOVE_GROWL),
     LEVEL_UP_MOVE(7, MOVE_ABSORB),
@@ -3889,7 +3889,7 @@ static const u16 sLotadLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLombreLevelUpLearnset[] = {
+static const struct LevelUpMove sLombreLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ASTONISH),
     LEVEL_UP_MOVE(3, MOVE_GROWL),
     LEVEL_UP_MOVE(7, MOVE_ABSORB),
@@ -3903,7 +3903,7 @@ static const u16 sLombreLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLudicoloLevelUpLearnset[] = {
+static const struct LevelUpMove sLudicoloLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ASTONISH),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_ABSORB),
@@ -3911,7 +3911,7 @@ static const u16 sLudicoloLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSeedotLevelUpLearnset[] = {
+static const struct LevelUpMove sSeedotLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BIDE),
     LEVEL_UP_MOVE(3, MOVE_HARDEN),
     LEVEL_UP_MOVE(7, MOVE_GROWTH),
@@ -3922,7 +3922,7 @@ static const u16 sSeedotLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sNuzleafLevelUpLearnset[] = {
+static const struct LevelUpMove sNuzleafLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(3, MOVE_HARDEN),
     LEVEL_UP_MOVE(7, MOVE_GROWTH),
@@ -3936,7 +3936,7 @@ static const u16 sNuzleafLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sShiftryLevelUpLearnset[] = {
+static const struct LevelUpMove sShiftryLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(1, MOVE_GROWTH),
@@ -3944,7 +3944,7 @@ static const u16 sShiftryLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sNincadaLevelUpLearnset[] = {
+static const struct LevelUpMove sNincadaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(5, MOVE_LEECH_LIFE),
@@ -3958,7 +3958,7 @@ static const u16 sNincadaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sNinjaskLevelUpLearnset[] = {
+static const struct LevelUpMove sNinjaskLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(1, MOVE_LEECH_LIFE),
@@ -3977,7 +3977,7 @@ static const u16 sNinjaskLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sShedinjaLevelUpLearnset[] = {
+static const struct LevelUpMove sShedinjaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(5, MOVE_LEECH_LIFE),
@@ -3991,7 +3991,7 @@ static const u16 sShedinjaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTaillowLevelUpLearnset[] = {
+static const struct LevelUpMove sTaillowLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(4, MOVE_FOCUS_ENERGY),
@@ -4004,7 +4004,7 @@ static const u16 sTaillowLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSwellowLevelUpLearnset[] = {
+static const struct LevelUpMove sSwellowLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_FOCUS_ENERGY),
@@ -4019,7 +4019,7 @@ static const u16 sSwellowLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sShroomishLevelUpLearnset[] = {
+static const struct LevelUpMove sShroomishLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ABSORB),
     LEVEL_UP_MOVE(4, MOVE_TACKLE),
     LEVEL_UP_MOVE(7, MOVE_STUN_SPORE),
@@ -4033,7 +4033,7 @@ static const u16 sShroomishLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sBreloomLevelUpLearnset[] = {
+static const struct LevelUpMove sBreloomLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ABSORB),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_STUN_SPORE),
@@ -4051,7 +4051,7 @@ static const u16 sBreloomLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSpindaLevelUpLearnset[] = {
+static const struct LevelUpMove sSpindaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(5, MOVE_UPROAR),
     LEVEL_UP_MOVE(12, MOVE_FAINT_ATTACK),
@@ -4066,7 +4066,7 @@ static const u16 sSpindaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sWingullLevelUpLearnset[] = {
+static const struct LevelUpMove sWingullLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_WATER_GUN),
     LEVEL_UP_MOVE(7, MOVE_SUPERSONIC),
@@ -4078,7 +4078,7 @@ static const u16 sWingullLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPelipperLevelUpLearnset[] = {
+static const struct LevelUpMove sPelipperLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_WATER_GUN),
     LEVEL_UP_MOVE(1, MOVE_WATER_SPORT),
@@ -4095,7 +4095,7 @@ static const u16 sPelipperLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSurskitLevelUpLearnset[] = {
+static const struct LevelUpMove sSurskitLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BUBBLE),
     LEVEL_UP_MOVE(7, MOVE_QUICK_ATTACK),
     LEVEL_UP_MOVE(13, MOVE_SWEET_SCENT),
@@ -4107,7 +4107,7 @@ static const u16 sSurskitLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMasquerainLevelUpLearnset[] = {
+static const struct LevelUpMove sMasquerainLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BUBBLE),
     LEVEL_UP_MOVE(1, MOVE_QUICK_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_SWEET_SCENT),
@@ -4123,7 +4123,7 @@ static const u16 sMasquerainLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sWailmerLevelUpLearnset[] = {
+static const struct LevelUpMove sWailmerLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SPLASH),
     LEVEL_UP_MOVE(5, MOVE_GROWL),
     LEVEL_UP_MOVE(10, MOVE_WATER_GUN),
@@ -4139,7 +4139,7 @@ static const u16 sWailmerLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sWailordLevelUpLearnset[] = {
+static const struct LevelUpMove sWailordLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SPLASH),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_WATER_GUN),
@@ -4158,7 +4158,7 @@ static const u16 sWailordLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSkittyLevelUpLearnset[] = {
+static const struct LevelUpMove sSkittyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(3, MOVE_TAIL_WHIP),
@@ -4174,7 +4174,7 @@ static const u16 sSkittyLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sDelcattyLevelUpLearnset[] = {
+static const struct LevelUpMove sDelcattyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_ATTRACT),
     LEVEL_UP_MOVE(1, MOVE_SING),
@@ -4182,7 +4182,7 @@ static const u16 sDelcattyLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sKecleonLevelUpLearnset[] = {
+static const struct LevelUpMove sKecleonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_THIEF),
     LEVEL_UP_MOVE(1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE(1, MOVE_ASTONISH),
@@ -4199,7 +4199,7 @@ static const u16 sKecleonLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sBaltoyLevelUpLearnset[] = {
+static const struct LevelUpMove sBaltoyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_CONFUSION),
     LEVEL_UP_MOVE(3, MOVE_HARDEN),
     LEVEL_UP_MOVE(5, MOVE_RAPID_SPIN),
@@ -4214,7 +4214,7 @@ static const u16 sBaltoyLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sClaydolLevelUpLearnset[] = {
+static const struct LevelUpMove sClaydolLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TELEPORT),
     LEVEL_UP_MOVE(1, MOVE_CONFUSION),
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
@@ -4233,7 +4233,7 @@ static const u16 sClaydolLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sNosepassLevelUpLearnset[] = {
+static const struct LevelUpMove sNosepassLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(7, MOVE_HARDEN),
     LEVEL_UP_MOVE(13, MOVE_ROCK_THROW),
@@ -4247,7 +4247,7 @@ static const u16 sNosepassLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTorkoalLevelUpLearnset[] = {
+static const struct LevelUpMove sTorkoalLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_EMBER),
     LEVEL_UP_MOVE(4, MOVE_SMOG),
     LEVEL_UP_MOVE(7, MOVE_CURSE),
@@ -4263,7 +4263,7 @@ static const u16 sTorkoalLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSableyeLevelUpLearnset[] = {
+static const struct LevelUpMove sSableyeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(5, MOVE_FORESIGHT),
@@ -4280,7 +4280,7 @@ static const u16 sSableyeLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sBarboachLevelUpLearnset[] = {
+static const struct LevelUpMove sBarboachLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_MUD_SLAP),
     LEVEL_UP_MOVE(6, MOVE_MUD_SPORT),
     LEVEL_UP_MOVE(6, MOVE_WATER_SPORT),
@@ -4295,7 +4295,7 @@ static const u16 sBarboachLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sWhiscashLevelUpLearnset[] = {
+static const struct LevelUpMove sWhiscashLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TICKLE),
     LEVEL_UP_MOVE(1, MOVE_MUD_SLAP),
     LEVEL_UP_MOVE(1, MOVE_MUD_SPORT),
@@ -4313,7 +4313,7 @@ static const u16 sWhiscashLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLuvdiscLevelUpLearnset[] = {
+static const struct LevelUpMove sLuvdiscLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(4, MOVE_CHARM),
     LEVEL_UP_MOVE(12, MOVE_WATER_GUN),
@@ -4326,7 +4326,7 @@ static const u16 sLuvdiscLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCorphishLevelUpLearnset[] = {
+static const struct LevelUpMove sCorphishLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BUBBLE),
     LEVEL_UP_MOVE(7, MOVE_HARDEN),
     LEVEL_UP_MOVE(10, MOVE_VICE_GRIP),
@@ -4342,7 +4342,7 @@ static const u16 sCorphishLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCrawdauntLevelUpLearnset[] = {
+static const struct LevelUpMove sCrawdauntLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BUBBLE),
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(1, MOVE_VICE_GRIP),
@@ -4361,14 +4361,14 @@ static const u16 sCrawdauntLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sFeebasLevelUpLearnset[] = {
+static const struct LevelUpMove sFeebasLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SPLASH),
     LEVEL_UP_MOVE(15, MOVE_TACKLE),
     LEVEL_UP_MOVE(30, MOVE_FLAIL),
     LEVEL_UP_END
 };
 
-static const u16 sMiloticLevelUpLearnset[] = {
+static const struct LevelUpMove sMiloticLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WATER_GUN),
     LEVEL_UP_MOVE(5, MOVE_WRAP),
     LEVEL_UP_MOVE(10, MOVE_WATER_SPORT),
@@ -4383,7 +4383,7 @@ static const u16 sMiloticLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCarvanhaLevelUpLearnset[] = {
+static const struct LevelUpMove sCarvanhaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_BITE),
     LEVEL_UP_MOVE(7, MOVE_RAGE),
@@ -4397,7 +4397,7 @@ static const u16 sCarvanhaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSharpedoLevelUpLearnset[] = {
+static const struct LevelUpMove sSharpedoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_BITE),
     LEVEL_UP_MOVE(1, MOVE_RAGE),
@@ -4415,7 +4415,7 @@ static const u16 sSharpedoLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTrapinchLevelUpLearnset[] = {
+static const struct LevelUpMove sTrapinchLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BITE),
     LEVEL_UP_MOVE(9, MOVE_SAND_ATTACK),
     LEVEL_UP_MOVE(17, MOVE_FAINT_ATTACK),
@@ -4427,7 +4427,7 @@ static const u16 sTrapinchLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sVibravaLevelUpLearnset[] = {
+static const struct LevelUpMove sVibravaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BITE),
     LEVEL_UP_MOVE(1, MOVE_SAND_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_FAINT_ATTACK),
@@ -4443,7 +4443,7 @@ static const u16 sVibravaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sFlygonLevelUpLearnset[] = {
+static const struct LevelUpMove sFlygonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BITE),
     LEVEL_UP_MOVE(1, MOVE_SAND_ATTACK),
     LEVEL_UP_MOVE(1, MOVE_FAINT_ATTACK),
@@ -4459,7 +4459,7 @@ static const u16 sFlygonLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMakuhitaLevelUpLearnset[] = {
+static const struct LevelUpMove sMakuhitaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_FOCUS_ENERGY),
     LEVEL_UP_MOVE(4, MOVE_SAND_ATTACK),
@@ -4476,7 +4476,7 @@ static const u16 sMakuhitaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sHariyamaLevelUpLearnset[] = {
+static const struct LevelUpMove sHariyamaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_FOCUS_ENERGY),
     LEVEL_UP_MOVE(1, MOVE_SAND_ATTACK),
@@ -4495,7 +4495,7 @@ static const u16 sHariyamaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sElectrikeLevelUpLearnset[] = {
+static const struct LevelUpMove sElectrikeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(4, MOVE_THUNDER_WAVE),
     LEVEL_UP_MOVE(9, MOVE_LEER),
@@ -4510,7 +4510,7 @@ static const u16 sElectrikeLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sManectricLevelUpLearnset[] = {
+static const struct LevelUpMove sManectricLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_THUNDER_WAVE),
     LEVEL_UP_MOVE(1, MOVE_LEER),
@@ -4528,7 +4528,7 @@ static const u16 sManectricLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sNumelLevelUpLearnset[] = {
+static const struct LevelUpMove sNumelLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(11, MOVE_EMBER),
@@ -4542,7 +4542,7 @@ static const u16 sNumelLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCameruptLevelUpLearnset[] = {
+static const struct LevelUpMove sCameruptLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_EMBER),
@@ -4559,7 +4559,7 @@ static const u16 sCameruptLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSphealLevelUpLearnset[] = {
+static const struct LevelUpMove sSphealLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POWDER_SNOW),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_DEFENSE_CURL),
@@ -4576,7 +4576,7 @@ static const u16 sSphealLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSealeoLevelUpLearnset[] = {
+static const struct LevelUpMove sSealeoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POWDER_SNOW),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_DEFENSE_CURL),
@@ -4593,7 +4593,7 @@ static const u16 sSealeoLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sWalreinLevelUpLearnset[] = {
+static const struct LevelUpMove sWalreinLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POWDER_SNOW),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_DEFENSE_CURL),
@@ -4610,7 +4610,7 @@ static const u16 sWalreinLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCacneaLevelUpLearnset[] = {
+static const struct LevelUpMove sCacneaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POISON_STING),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(5, MOVE_ABSORB),
@@ -4628,7 +4628,7 @@ static const u16 sCacneaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCacturneLevelUpLearnset[] = {
+static const struct LevelUpMove sCacturneLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_REVENGE),
     LEVEL_UP_MOVE(1, MOVE_POISON_STING),
     LEVEL_UP_MOVE(1, MOVE_LEER),
@@ -4649,7 +4649,7 @@ static const u16 sCacturneLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSnoruntLevelUpLearnset[] = {
+static const struct LevelUpMove sSnoruntLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POWDER_SNOW),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(7, MOVE_DOUBLE_TEAM),
@@ -4664,7 +4664,7 @@ static const u16 sSnoruntLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGlalieLevelUpLearnset[] = {
+static const struct LevelUpMove sGlalieLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POWDER_SNOW),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_DOUBLE_TEAM),
@@ -4682,7 +4682,7 @@ static const u16 sGlalieLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLunatoneLevelUpLearnset[] = {
+static const struct LevelUpMove sLunatoneLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(7, MOVE_CONFUSION),
@@ -4696,7 +4696,7 @@ static const u16 sLunatoneLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSolrockLevelUpLearnset[] = {
+static const struct LevelUpMove sSolrockLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(7, MOVE_CONFUSION),
@@ -4710,7 +4710,7 @@ static const u16 sSolrockLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sAzurillLevelUpLearnset[] = {
+static const struct LevelUpMove sAzurillLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SPLASH),
     LEVEL_UP_MOVE(3, MOVE_CHARM),
     LEVEL_UP_MOVE(6, MOVE_TAIL_WHIP),
@@ -4720,7 +4720,7 @@ static const u16 sAzurillLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSpoinkLevelUpLearnset[] = {
+static const struct LevelUpMove sSpoinkLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SPLASH),
     LEVEL_UP_MOVE(7, MOVE_PSYWAVE),
     LEVEL_UP_MOVE(10, MOVE_ODOR_SLEUTH),
@@ -4735,7 +4735,7 @@ static const u16 sSpoinkLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGrumpigLevelUpLearnset[] = {
+static const struct LevelUpMove sGrumpigLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SPLASH),
     LEVEL_UP_MOVE(1, MOVE_PSYWAVE),
     LEVEL_UP_MOVE(1, MOVE_ODOR_SLEUTH),
@@ -4753,7 +4753,7 @@ static const u16 sGrumpigLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sPlusleLevelUpLearnset[] = {
+static const struct LevelUpMove sPlusleLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(4, MOVE_THUNDER_WAVE),
     LEVEL_UP_MOVE(10, MOVE_QUICK_ATTACK),
@@ -4768,7 +4768,7 @@ static const u16 sPlusleLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMinunLevelUpLearnset[] = {
+static const struct LevelUpMove sMinunLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(4, MOVE_THUNDER_WAVE),
     LEVEL_UP_MOVE(10, MOVE_QUICK_ATTACK),
@@ -4783,7 +4783,7 @@ static const u16 sMinunLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMawileLevelUpLearnset[] = {
+static const struct LevelUpMove sMawileLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ASTONISH),
     LEVEL_UP_MOVE(6, MOVE_FAKE_TEARS),
     LEVEL_UP_MOVE(11, MOVE_BITE),
@@ -4799,7 +4799,7 @@ static const u16 sMawileLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMedititeLevelUpLearnset[] = {
+static const struct LevelUpMove sMedititeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BIDE),
     LEVEL_UP_MOVE(4, MOVE_MEDITATE),
     LEVEL_UP_MOVE(9, MOVE_CONFUSION),
@@ -4815,7 +4815,7 @@ static const u16 sMedititeLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMedichamLevelUpLearnset[] = {
+static const struct LevelUpMove sMedichamLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_FIRE_PUNCH),
     LEVEL_UP_MOVE(1, MOVE_THUNDER_PUNCH),
     LEVEL_UP_MOVE(1, MOVE_ICE_PUNCH),
@@ -4837,7 +4837,7 @@ static const u16 sMedichamLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSwabluLevelUpLearnset[] = {
+static const struct LevelUpMove sSwabluLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(8, MOVE_ASTONISH),
@@ -4852,7 +4852,7 @@ static const u16 sSwabluLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sAltariaLevelUpLearnset[] = {
+static const struct LevelUpMove sAltariaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PECK),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_ASTONISH),
@@ -4871,7 +4871,7 @@ static const u16 sAltariaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sWynautLevelUpLearnset[] = {
+static const struct LevelUpMove sWynautLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SPLASH),
     LEVEL_UP_MOVE(1, MOVE_CHARM),
     LEVEL_UP_MOVE(1, MOVE_ENCORE),
@@ -4882,7 +4882,7 @@ static const u16 sWynautLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sDuskullLevelUpLearnset[] = {
+static const struct LevelUpMove sDuskullLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_NIGHT_SHADE),
     LEVEL_UP_MOVE(5, MOVE_DISABLE),
@@ -4897,7 +4897,7 @@ static const u16 sDuskullLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sDusclopsLevelUpLearnset[] = {
+static const struct LevelUpMove sDusclopsLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_BIND),
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_NIGHT_SHADE),
@@ -4915,7 +4915,7 @@ static const u16 sDusclopsLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sRoseliaLevelUpLearnset[] = {
+static const struct LevelUpMove sRoseliaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ABSORB),
     LEVEL_UP_MOVE(5, MOVE_GROWTH),
     LEVEL_UP_MOVE(9, MOVE_POISON_STING),
@@ -4934,7 +4934,7 @@ static const u16 sRoseliaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSlakothLevelUpLearnset[] = {
+static const struct LevelUpMove sSlakothLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_YAWN),
     LEVEL_UP_MOVE(7, MOVE_ENCORE),
@@ -4947,7 +4947,7 @@ static const u16 sSlakothLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sVigorothLevelUpLearnset[] = {
+static const struct LevelUpMove sVigorothLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_FOCUS_ENERGY),
     LEVEL_UP_MOVE(1, MOVE_ENCORE),
@@ -4963,7 +4963,7 @@ static const u16 sVigorothLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSlakingLevelUpLearnset[] = {
+static const struct LevelUpMove sSlakingLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_YAWN),
     LEVEL_UP_MOVE(1, MOVE_ENCORE),
@@ -4979,7 +4979,7 @@ static const u16 sSlakingLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGulpinLevelUpLearnset[] = {
+static const struct LevelUpMove sGulpinLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(6, MOVE_YAWN),
     LEVEL_UP_MOVE(9, MOVE_POISON_GAS),
@@ -4994,7 +4994,7 @@ static const u16 sGulpinLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSwalotLevelUpLearnset[] = {
+static const struct LevelUpMove sSwalotLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(1, MOVE_YAWN),
     LEVEL_UP_MOVE(1, MOVE_POISON_GAS),
@@ -5013,7 +5013,7 @@ static const u16 sSwalotLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTropiusLevelUpLearnset[] = {
+static const struct LevelUpMove sTropiusLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_GUST),
     LEVEL_UP_MOVE(7, MOVE_GROWTH),
@@ -5028,7 +5028,7 @@ static const u16 sTropiusLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sWhismurLevelUpLearnset[] = {
+static const struct LevelUpMove sWhismurLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(5, MOVE_UPROAR),
     LEVEL_UP_MOVE(11, MOVE_ASTONISH),
@@ -5043,7 +5043,7 @@ static const u16 sWhismurLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLoudredLevelUpLearnset[] = {
+static const struct LevelUpMove sLoudredLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(1, MOVE_UPROAR),
     LEVEL_UP_MOVE(1, MOVE_ASTONISH),
@@ -5061,7 +5061,7 @@ static const u16 sLoudredLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sExploudLevelUpLearnset[] = {
+static const struct LevelUpMove sExploudLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_POUND),
     LEVEL_UP_MOVE(1, MOVE_UPROAR),
     LEVEL_UP_MOVE(1, MOVE_ASTONISH),
@@ -5080,7 +5080,7 @@ static const u16 sExploudLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sClamperlLevelUpLearnset[] = {
+static const struct LevelUpMove sClamperlLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_CLAMP),
     LEVEL_UP_MOVE(1, MOVE_WATER_GUN),
     LEVEL_UP_MOVE(1, MOVE_WHIRLPOOL),
@@ -5088,7 +5088,7 @@ static const u16 sClamperlLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sHuntailLevelUpLearnset[] = {
+static const struct LevelUpMove sHuntailLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WHIRLPOOL),
     LEVEL_UP_MOVE(8, MOVE_BITE),
     LEVEL_UP_MOVE(15, MOVE_SCREECH),
@@ -5100,7 +5100,7 @@ static const u16 sHuntailLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGorebyssLevelUpLearnset[] = {
+static const struct LevelUpMove sGorebyssLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WHIRLPOOL),
     LEVEL_UP_MOVE(8, MOVE_CONFUSION),
     LEVEL_UP_MOVE(15, MOVE_AGILITY),
@@ -5112,7 +5112,7 @@ static const u16 sGorebyssLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sAbsolLevelUpLearnset[] = {
+static const struct LevelUpMove sAbsolLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(5, MOVE_LEER),
     LEVEL_UP_MOVE(9, MOVE_TAUNT),
@@ -5127,7 +5127,7 @@ static const u16 sAbsolLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sShuppetLevelUpLearnset[] = {
+static const struct LevelUpMove sShuppetLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_KNOCK_OFF),
     LEVEL_UP_MOVE(8, MOVE_SCREECH),
     LEVEL_UP_MOVE(13, MOVE_NIGHT_SHADE),
@@ -5141,7 +5141,7 @@ static const u16 sShuppetLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sBanetteLevelUpLearnset[] = {
+static const struct LevelUpMove sBanetteLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_KNOCK_OFF),
     LEVEL_UP_MOVE(1, MOVE_SCREECH),
     LEVEL_UP_MOVE(1, MOVE_NIGHT_SHADE),
@@ -5158,7 +5158,7 @@ static const u16 sBanetteLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSeviperLevelUpLearnset[] = {
+static const struct LevelUpMove sSeviperLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WRAP),
     LEVEL_UP_MOVE(7, MOVE_LICK),
     LEVEL_UP_MOVE(10, MOVE_BITE),
@@ -5172,7 +5172,7 @@ static const u16 sSeviperLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sZangooseLevelUpLearnset[] = {
+static const struct LevelUpMove sZangooseLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(4, MOVE_LEER),
     LEVEL_UP_MOVE(7, MOVE_QUICK_ATTACK),
@@ -5187,7 +5187,7 @@ static const u16 sZangooseLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sRelicanthLevelUpLearnset[] = {
+static const struct LevelUpMove sRelicanthLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(8, MOVE_WATER_GUN),
@@ -5202,7 +5202,7 @@ static const u16 sRelicanthLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sAronLevelUpLearnset[] = {
+static const struct LevelUpMove sAronLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(4, MOVE_HARDEN),
     LEVEL_UP_MOVE(7, MOVE_MUD_SLAP),
@@ -5218,7 +5218,7 @@ static const u16 sAronLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLaironLevelUpLearnset[] = {
+static const struct LevelUpMove sLaironLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(1, MOVE_MUD_SLAP),
@@ -5237,7 +5237,7 @@ static const u16 sLaironLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sAggronLevelUpLearnset[] = {
+static const struct LevelUpMove sAggronLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(1, MOVE_MUD_SLAP),
@@ -5256,7 +5256,7 @@ static const u16 sAggronLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCastformLevelUpLearnset[] = {
+static const struct LevelUpMove sCastformLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(10, MOVE_WATER_GUN),
     LEVEL_UP_MOVE(10, MOVE_EMBER),
@@ -5268,7 +5268,7 @@ static const u16 sCastformLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sVolbeatLevelUpLearnset[] = {
+static const struct LevelUpMove sVolbeatLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(5, MOVE_CONFUSE_RAY),
     LEVEL_UP_MOVE(9, MOVE_DOUBLE_TEAM),
@@ -5282,7 +5282,7 @@ static const u16 sVolbeatLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sIllumiseLevelUpLearnset[] = {
+static const struct LevelUpMove sIllumiseLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TACKLE),
     LEVEL_UP_MOVE(5, MOVE_SWEET_SCENT),
     LEVEL_UP_MOVE(9, MOVE_CHARM),
@@ -5296,7 +5296,7 @@ static const u16 sIllumiseLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLileepLevelUpLearnset[] = {
+static const struct LevelUpMove sLileepLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ASTONISH),
     LEVEL_UP_MOVE(8, MOVE_CONSTRICT),
     LEVEL_UP_MOVE(15, MOVE_ACID),
@@ -5310,7 +5310,7 @@ static const u16 sLileepLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sCradilyLevelUpLearnset[] = {
+static const struct LevelUpMove sCradilyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_ASTONISH),
     LEVEL_UP_MOVE(1, MOVE_CONSTRICT),
     LEVEL_UP_MOVE(1, MOVE_ACID),
@@ -5327,7 +5327,7 @@ static const u16 sCradilyLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sAnorithLevelUpLearnset[] = {
+static const struct LevelUpMove sAnorithLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(7, MOVE_HARDEN),
     LEVEL_UP_MOVE(13, MOVE_MUD_SPORT),
@@ -5341,7 +5341,7 @@ static const u16 sAnorithLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sArmaldoLevelUpLearnset[] = {
+static const struct LevelUpMove sArmaldoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_SCRATCH),
     LEVEL_UP_MOVE(1, MOVE_HARDEN),
     LEVEL_UP_MOVE(1, MOVE_MUD_SPORT),
@@ -5358,7 +5358,7 @@ static const u16 sArmaldoLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sRaltsLevelUpLearnset[] = {
+static const struct LevelUpMove sRaltsLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(6, MOVE_CONFUSION),
     LEVEL_UP_MOVE(11, MOVE_DOUBLE_TEAM),
@@ -5372,7 +5372,7 @@ static const u16 sRaltsLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sKirliaLevelUpLearnset[] = {
+static const struct LevelUpMove sKirliaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_MAGICAL_LEAF),
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_CONFUSION),
@@ -5390,7 +5390,7 @@ static const u16 sKirliaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGardevoirLevelUpLearnset[] = {
+static const struct LevelUpMove sGardevoirLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_GROWL),
     LEVEL_UP_MOVE(1, MOVE_CONFUSION),
     LEVEL_UP_MOVE(1, MOVE_DOUBLE_TEAM),
@@ -5407,7 +5407,7 @@ static const u16 sGardevoirLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sBagonLevelUpLearnset[] = {
+static const struct LevelUpMove sBagonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_RAGE),
     LEVEL_UP_MOVE(5, MOVE_BITE),
     LEVEL_UP_MOVE(9, MOVE_LEER),
@@ -5422,7 +5422,7 @@ static const u16 sBagonLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sShelgonLevelUpLearnset[] = {
+static const struct LevelUpMove sShelgonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_RAGE),
     LEVEL_UP_MOVE(1, MOVE_BITE),
     LEVEL_UP_MOVE(1, MOVE_LEER),
@@ -5441,7 +5441,7 @@ static const u16 sShelgonLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sSalamenceLevelUpLearnset[] = {
+static const struct LevelUpMove sSalamenceLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_RAGE),
     LEVEL_UP_MOVE(1, MOVE_BITE),
     LEVEL_UP_MOVE(1, MOVE_LEER),
@@ -5461,12 +5461,12 @@ static const u16 sSalamenceLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sBeldumLevelUpLearnset[] = {
+static const struct LevelUpMove sBeldumLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TAKE_DOWN),
     LEVEL_UP_END
 };
 
-static const u16 sMetangLevelUpLearnset[] = {
+static const struct LevelUpMove sMetangLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(20, MOVE_CONFUSION),
     LEVEL_UP_MOVE(20, MOVE_METAL_CLAW),
@@ -5480,7 +5480,7 @@ static const u16 sMetangLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sMetagrossLevelUpLearnset[] = {
+static const struct LevelUpMove sMetagrossLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(1, MOVE_CONFUSION),
     LEVEL_UP_MOVE(1, MOVE_METAL_CLAW),
@@ -5497,7 +5497,7 @@ static const u16 sMetagrossLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sRegirockLevelUpLearnset[] = {
+static const struct LevelUpMove sRegirockLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_EXPLOSION),
     LEVEL_UP_MOVE(9, MOVE_ROCK_THROW),
     LEVEL_UP_MOVE(17, MOVE_CURSE),
@@ -5510,7 +5510,7 @@ static const u16 sRegirockLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sRegiceLevelUpLearnset[] = {
+static const struct LevelUpMove sRegiceLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_EXPLOSION),
     LEVEL_UP_MOVE(9, MOVE_ICY_WIND),
     LEVEL_UP_MOVE(17, MOVE_CURSE),
@@ -5523,7 +5523,7 @@ static const u16 sRegiceLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sRegisteelLevelUpLearnset[] = {
+static const struct LevelUpMove sRegisteelLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_EXPLOSION),
     LEVEL_UP_MOVE(9, MOVE_METAL_CLAW),
     LEVEL_UP_MOVE(17, MOVE_CURSE),
@@ -5537,7 +5537,7 @@ static const u16 sRegisteelLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sKyogreLevelUpLearnset[] = {
+static const struct LevelUpMove sKyogreLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WATER_PULSE),
     LEVEL_UP_MOVE(5, MOVE_SCARY_FACE),
     LEVEL_UP_MOVE(15, MOVE_ANCIENT_POWER),
@@ -5552,7 +5552,7 @@ static const u16 sKyogreLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sGroudonLevelUpLearnset[] = {
+static const struct LevelUpMove sGroudonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_MUD_SHOT),
     LEVEL_UP_MOVE(5, MOVE_SCARY_FACE),
     LEVEL_UP_MOVE(15, MOVE_ANCIENT_POWER),
@@ -5567,7 +5567,7 @@ static const u16 sGroudonLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sRayquazaLevelUpLearnset[] = {
+static const struct LevelUpMove sRayquazaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_TWISTER),
     LEVEL_UP_MOVE(5, MOVE_SCARY_FACE),
     LEVEL_UP_MOVE(15, MOVE_ANCIENT_POWER),
@@ -5582,7 +5582,7 @@ static const u16 sRayquazaLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLatiasLevelUpLearnset[] = {
+static const struct LevelUpMove sLatiasLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PSYWAVE),
     LEVEL_UP_MOVE(5, MOVE_WISH),
     LEVEL_UP_MOVE(10, MOVE_HELPING_HAND),
@@ -5597,7 +5597,7 @@ static const u16 sLatiasLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sLatiosLevelUpLearnset[] = {
+static const struct LevelUpMove sLatiosLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_PSYWAVE),
     LEVEL_UP_MOVE(5, MOVE_MEMENTO),
     LEVEL_UP_MOVE(10, MOVE_HELPING_HAND),
@@ -5612,7 +5612,7 @@ static const u16 sLatiosLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sJirachiLevelUpLearnset[] = {
+static const struct LevelUpMove sJirachiLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WISH),
     LEVEL_UP_MOVE(1, MOVE_CONFUSION),
     LEVEL_UP_MOVE(5, MOVE_REST),
@@ -5629,7 +5629,7 @@ static const u16 sJirachiLevelUpLearnset[] = {
 };
 
 #if defined(FIRERED)
-static const u16 sDeoxysLevelUpLearnset[] = {
+static const struct LevelUpMove sDeoxysLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_WRAP),
     LEVEL_UP_MOVE(5, MOVE_NIGHT_SHADE),
@@ -5645,7 +5645,7 @@ static const u16 sDeoxysLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 #elif defined(LEAFGREEN)
-static const u16 sDeoxysLevelUpLearnset[] = {
+static const struct LevelUpMove sDeoxysLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_LEER),
     LEVEL_UP_MOVE(1, MOVE_WRAP),
     LEVEL_UP_MOVE(5, MOVE_NIGHT_SHADE),
@@ -5664,7 +5664,7 @@ static const u16 sDeoxysLevelUpLearnset[] = {
 };
 #endif
 
-static const u16 sChimechoLevelUpLearnset[] = {
+static const struct LevelUpMove sChimechoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(1, MOVE_WRAP),
     LEVEL_UP_MOVE(6, MOVE_GROWL),
     LEVEL_UP_MOVE(9, MOVE_ASTONISH),
@@ -5680,4124 +5680,4124 @@ static const u16 sChimechoLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-static const u16 sTurtwigLevelUpLearnset[] = {
+static const struct LevelUpMove sTurtwigLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGrotleLevelUpLearnset[] = {
+static const struct LevelUpMove sGrotleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTorterraLevelUpLearnset[] = {
+static const struct LevelUpMove sTorterraLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sChimcharLevelUpLearnset[] = {
+static const struct LevelUpMove sChimcharLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMonfernoLevelUpLearnset[] = {
+static const struct LevelUpMove sMonfernoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sInfernapeLevelUpLearnset[] = {
+static const struct LevelUpMove sInfernapeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPiplupLevelUpLearnset[] = {
+static const struct LevelUpMove sPiplupLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPrinplupLevelUpLearnset[] = {
+static const struct LevelUpMove sPrinplupLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sEmpoleonLevelUpLearnset[] = {
+static const struct LevelUpMove sEmpoleonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sStarlyLevelUpLearnset[] = {
+static const struct LevelUpMove sStarlyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sStaraviaLevelUpLearnset[] = {
+static const struct LevelUpMove sStaraviaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sStaraptorLevelUpLearnset[] = {
+static const struct LevelUpMove sStaraptorLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBidoofLevelUpLearnset[] = {
+static const struct LevelUpMove sBidoofLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBibarelLevelUpLearnset[] = {
+static const struct LevelUpMove sBibarelLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKricketotLevelUpLearnset[] = {
+static const struct LevelUpMove sKricketotLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKricketuneLevelUpLearnset[] = {
+static const struct LevelUpMove sKricketuneLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sShinxLevelUpLearnset[] = {
+static const struct LevelUpMove sShinxLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLuxioLevelUpLearnset[] = {
+static const struct LevelUpMove sLuxioLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLuxrayLevelUpLearnset[] = {
+static const struct LevelUpMove sLuxrayLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBudewLevelUpLearnset[] = {
+static const struct LevelUpMove sBudewLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRoseradeLevelUpLearnset[] = {
+static const struct LevelUpMove sRoseradeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCranidosLevelUpLearnset[] = {
+static const struct LevelUpMove sCranidosLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRampardosLevelUpLearnset[] = {
+static const struct LevelUpMove sRampardosLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sShieldonLevelUpLearnset[] = {
+static const struct LevelUpMove sShieldonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBastiodonLevelUpLearnset[] = {
+static const struct LevelUpMove sBastiodonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBurmyLevelUpLearnset[] = {
+static const struct LevelUpMove sBurmyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWormadamLevelUpLearnset[] = {
+static const struct LevelUpMove sWormadamLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMothimLevelUpLearnset[] = {
+static const struct LevelUpMove sMothimLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCombeeLevelUpLearnset[] = {
+static const struct LevelUpMove sCombeeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVespiquenLevelUpLearnset[] = {
+static const struct LevelUpMove sVespiquenLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPachirisuLevelUpLearnset[] = {
+static const struct LevelUpMove sPachirisuLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBuizelLevelUpLearnset[] = {
+static const struct LevelUpMove sBuizelLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFloatzelLevelUpLearnset[] = {
+static const struct LevelUpMove sFloatzelLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCherubiLevelUpLearnset[] = {
+static const struct LevelUpMove sCherubiLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCherrimLevelUpLearnset[] = {
+static const struct LevelUpMove sCherrimLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sShellosLevelUpLearnset[] = {
+static const struct LevelUpMove sShellosLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGastrodonLevelUpLearnset[] = {
+static const struct LevelUpMove sGastrodonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAmbipomLevelUpLearnset[] = {
+static const struct LevelUpMove sAmbipomLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDrifloonLevelUpLearnset[] = {
+static const struct LevelUpMove sDrifloonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDrifblimLevelUpLearnset[] = {
+static const struct LevelUpMove sDrifblimLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBunearyLevelUpLearnset[] = {
+static const struct LevelUpMove sBunearyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLopunnyLevelUpLearnset[] = {
+static const struct LevelUpMove sLopunnyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMismagiusLevelUpLearnset[] = {
+static const struct LevelUpMove sMismagiusLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHonchkrowLevelUpLearnset[] = {
+static const struct LevelUpMove sHonchkrowLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGlameowLevelUpLearnset[] = {
+static const struct LevelUpMove sGlameowLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPuruglyLevelUpLearnset[] = {
+static const struct LevelUpMove sPuruglyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sChinglingLevelUpLearnset[] = {
+static const struct LevelUpMove sChinglingLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sStunkyLevelUpLearnset[] = {
+static const struct LevelUpMove sStunkyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSkuntankLevelUpLearnset[] = {
+static const struct LevelUpMove sSkuntankLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBronzorLevelUpLearnset[] = {
+static const struct LevelUpMove sBronzorLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBronzongLevelUpLearnset[] = {
+static const struct LevelUpMove sBronzongLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBonslyLevelUpLearnset[] = {
+static const struct LevelUpMove sBonslyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMime_Jr_LevelUpLearnset[] = {
+static const struct LevelUpMove sMime_Jr_LevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHappinyLevelUpLearnset[] = {
+static const struct LevelUpMove sHappinyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sChatotLevelUpLearnset[] = {
+static const struct LevelUpMove sChatotLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSpiritombLevelUpLearnset[] = {
+static const struct LevelUpMove sSpiritombLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGibleLevelUpLearnset[] = {
+static const struct LevelUpMove sGibleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGabiteLevelUpLearnset[] = {
+static const struct LevelUpMove sGabiteLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGarchompLevelUpLearnset[] = {
+static const struct LevelUpMove sGarchompLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMunchlaxLevelUpLearnset[] = {
+static const struct LevelUpMove sMunchlaxLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRioluLevelUpLearnset[] = {
+static const struct LevelUpMove sRioluLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLucarioLevelUpLearnset[] = {
+static const struct LevelUpMove sLucarioLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHippopotasLevelUpLearnset[] = {
+static const struct LevelUpMove sHippopotasLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHippowdonLevelUpLearnset[] = {
+static const struct LevelUpMove sHippowdonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSkorupiLevelUpLearnset[] = {
+static const struct LevelUpMove sSkorupiLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDrapionLevelUpLearnset[] = {
+static const struct LevelUpMove sDrapionLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCroagunkLevelUpLearnset[] = {
+static const struct LevelUpMove sCroagunkLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sToxicroakLevelUpLearnset[] = {
+static const struct LevelUpMove sToxicroakLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCarnivineLevelUpLearnset[] = {
+static const struct LevelUpMove sCarnivineLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFinneonLevelUpLearnset[] = {
+static const struct LevelUpMove sFinneonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLumineonLevelUpLearnset[] = {
+static const struct LevelUpMove sLumineonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMantykeLevelUpLearnset[] = {
+static const struct LevelUpMove sMantykeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSnoverLevelUpLearnset[] = {
+static const struct LevelUpMove sSnoverLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAbomasnowLevelUpLearnset[] = {
+static const struct LevelUpMove sAbomasnowLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWeavileLevelUpLearnset[] = {
+static const struct LevelUpMove sWeavileLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMagnezoneLevelUpLearnset[] = {
+static const struct LevelUpMove sMagnezoneLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLickilickyLevelUpLearnset[] = {
+static const struct LevelUpMove sLickilickyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRhyperiorLevelUpLearnset[] = {
+static const struct LevelUpMove sRhyperiorLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTangrowthLevelUpLearnset[] = {
+static const struct LevelUpMove sTangrowthLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sElectivireLevelUpLearnset[] = {
+static const struct LevelUpMove sElectivireLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMagmortarLevelUpLearnset[] = {
+static const struct LevelUpMove sMagmortarLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTogekissLevelUpLearnset[] = {
+static const struct LevelUpMove sTogekissLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sYanmegaLevelUpLearnset[] = {
+static const struct LevelUpMove sYanmegaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLeafeonLevelUpLearnset[] = {
+static const struct LevelUpMove sLeafeonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGlaceonLevelUpLearnset[] = {
+static const struct LevelUpMove sGlaceonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGliscorLevelUpLearnset[] = {
+static const struct LevelUpMove sGliscorLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMamoswineLevelUpLearnset[] = {
+static const struct LevelUpMove sMamoswineLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPorygon_ZLevelUpLearnset[] = {
+static const struct LevelUpMove sPorygon_ZLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGalladeLevelUpLearnset[] = {
+static const struct LevelUpMove sGalladeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sProbopassLevelUpLearnset[] = {
+static const struct LevelUpMove sProbopassLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDusknoirLevelUpLearnset[] = {
+static const struct LevelUpMove sDusknoirLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFroslassLevelUpLearnset[] = {
+static const struct LevelUpMove sFroslassLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRotomLevelUpLearnset[] = {
+static const struct LevelUpMove sRotomLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sUxieLevelUpLearnset[] = {
+static const struct LevelUpMove sUxieLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMespritLevelUpLearnset[] = {
+static const struct LevelUpMove sMespritLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAzelfLevelUpLearnset[] = {
+static const struct LevelUpMove sAzelfLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDialgaLevelUpLearnset[] = {
+static const struct LevelUpMove sDialgaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPalkiaLevelUpLearnset[] = {
+static const struct LevelUpMove sPalkiaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHeatranLevelUpLearnset[] = {
+static const struct LevelUpMove sHeatranLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRegigigasLevelUpLearnset[] = {
+static const struct LevelUpMove sRegigigasLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGiratinaLevelUpLearnset[] = {
+static const struct LevelUpMove sGiratinaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCresseliaLevelUpLearnset[] = {
+static const struct LevelUpMove sCresseliaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPhioneLevelUpLearnset[] = {
+static const struct LevelUpMove sPhioneLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sManaphyLevelUpLearnset[] = {
+static const struct LevelUpMove sManaphyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDarkraiLevelUpLearnset[] = {
+static const struct LevelUpMove sDarkraiLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sShayminLevelUpLearnset[] = {
+static const struct LevelUpMove sShayminLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sArceusLevelUpLearnset[] = {
+static const struct LevelUpMove sArceusLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVictiniLevelUpLearnset[] = {
+static const struct LevelUpMove sVictiniLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSnivyLevelUpLearnset[] = {
+static const struct LevelUpMove sSnivyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sServineLevelUpLearnset[] = {
+static const struct LevelUpMove sServineLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSerperiorLevelUpLearnset[] = {
+static const struct LevelUpMove sSerperiorLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTepigLevelUpLearnset[] = {
+static const struct LevelUpMove sTepigLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPigniteLevelUpLearnset[] = {
+static const struct LevelUpMove sPigniteLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sEmboarLevelUpLearnset[] = {
+static const struct LevelUpMove sEmboarLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sOshawottLevelUpLearnset[] = {
+static const struct LevelUpMove sOshawottLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDewottLevelUpLearnset[] = {
+static const struct LevelUpMove sDewottLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSamurottLevelUpLearnset[] = {
+static const struct LevelUpMove sSamurottLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPatratLevelUpLearnset[] = {
+static const struct LevelUpMove sPatratLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWatchogLevelUpLearnset[] = {
+static const struct LevelUpMove sWatchogLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLillipupLevelUpLearnset[] = {
+static const struct LevelUpMove sLillipupLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHerdierLevelUpLearnset[] = {
+static const struct LevelUpMove sHerdierLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sStoutlandLevelUpLearnset[] = {
+static const struct LevelUpMove sStoutlandLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPurrloinLevelUpLearnset[] = {
+static const struct LevelUpMove sPurrloinLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLiepardLevelUpLearnset[] = {
+static const struct LevelUpMove sLiepardLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPansageLevelUpLearnset[] = {
+static const struct LevelUpMove sPansageLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSimisageLevelUpLearnset[] = {
+static const struct LevelUpMove sSimisageLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPansearLevelUpLearnset[] = {
+static const struct LevelUpMove sPansearLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSimisearLevelUpLearnset[] = {
+static const struct LevelUpMove sSimisearLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPanpourLevelUpLearnset[] = {
+static const struct LevelUpMove sPanpourLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSimipourLevelUpLearnset[] = {
+static const struct LevelUpMove sSimipourLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMunnaLevelUpLearnset[] = {
+static const struct LevelUpMove sMunnaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMusharnaLevelUpLearnset[] = {
+static const struct LevelUpMove sMusharnaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPidoveLevelUpLearnset[] = {
+static const struct LevelUpMove sPidoveLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTranquillLevelUpLearnset[] = {
+static const struct LevelUpMove sTranquillLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sUnfezantLevelUpLearnset[] = {
+static const struct LevelUpMove sUnfezantLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBlitzleLevelUpLearnset[] = {
+static const struct LevelUpMove sBlitzleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sZebstrikaLevelUpLearnset[] = {
+static const struct LevelUpMove sZebstrikaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRoggenrolaLevelUpLearnset[] = {
+static const struct LevelUpMove sRoggenrolaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBoldoreLevelUpLearnset[] = {
+static const struct LevelUpMove sBoldoreLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGigalithLevelUpLearnset[] = {
+static const struct LevelUpMove sGigalithLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWoobatLevelUpLearnset[] = {
+static const struct LevelUpMove sWoobatLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSwoobatLevelUpLearnset[] = {
+static const struct LevelUpMove sSwoobatLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDrilburLevelUpLearnset[] = {
+static const struct LevelUpMove sDrilburLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sExcadrillLevelUpLearnset[] = {
+static const struct LevelUpMove sExcadrillLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAudinoLevelUpLearnset[] = {
+static const struct LevelUpMove sAudinoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTimburrLevelUpLearnset[] = {
+static const struct LevelUpMove sTimburrLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGurdurrLevelUpLearnset[] = {
+static const struct LevelUpMove sGurdurrLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sConkeldurrLevelUpLearnset[] = {
+static const struct LevelUpMove sConkeldurrLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTympoleLevelUpLearnset[] = {
+static const struct LevelUpMove sTympoleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPalpitoadLevelUpLearnset[] = {
+static const struct LevelUpMove sPalpitoadLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSeismitoadLevelUpLearnset[] = {
+static const struct LevelUpMove sSeismitoadLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sThrohLevelUpLearnset[] = {
+static const struct LevelUpMove sThrohLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSawkLevelUpLearnset[] = {
+static const struct LevelUpMove sSawkLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSewaddleLevelUpLearnset[] = {
+static const struct LevelUpMove sSewaddleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSwadloonLevelUpLearnset[] = {
+static const struct LevelUpMove sSwadloonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLeavannyLevelUpLearnset[] = {
+static const struct LevelUpMove sLeavannyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVenipedeLevelUpLearnset[] = {
+static const struct LevelUpMove sVenipedeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWhirlipedeLevelUpLearnset[] = {
+static const struct LevelUpMove sWhirlipedeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sScolipedeLevelUpLearnset[] = {
+static const struct LevelUpMove sScolipedeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCottoneeLevelUpLearnset[] = {
+static const struct LevelUpMove sCottoneeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWhimsicottLevelUpLearnset[] = {
+static const struct LevelUpMove sWhimsicottLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPetililLevelUpLearnset[] = {
+static const struct LevelUpMove sPetililLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLilligantLevelUpLearnset[] = {
+static const struct LevelUpMove sLilligantLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBasculinLevelUpLearnset[] = {
+static const struct LevelUpMove sBasculinLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSandileLevelUpLearnset[] = {
+static const struct LevelUpMove sSandileLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKrokorokLevelUpLearnset[] = {
+static const struct LevelUpMove sKrokorokLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKrookodileLevelUpLearnset[] = {
+static const struct LevelUpMove sKrookodileLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDarumakaLevelUpLearnset[] = {
+static const struct LevelUpMove sDarumakaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDarmanitanLevelUpLearnset[] = {
+static const struct LevelUpMove sDarmanitanLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMaractusLevelUpLearnset[] = {
+static const struct LevelUpMove sMaractusLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDwebbleLevelUpLearnset[] = {
+static const struct LevelUpMove sDwebbleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCrustleLevelUpLearnset[] = {
+static const struct LevelUpMove sCrustleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sScraggyLevelUpLearnset[] = {
+static const struct LevelUpMove sScraggyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sScraftyLevelUpLearnset[] = {
+static const struct LevelUpMove sScraftyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSigilyphLevelUpLearnset[] = {
+static const struct LevelUpMove sSigilyphLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sYamaskLevelUpLearnset[] = {
+static const struct LevelUpMove sYamaskLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCofagrigusLevelUpLearnset[] = {
+static const struct LevelUpMove sCofagrigusLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTirtougaLevelUpLearnset[] = {
+static const struct LevelUpMove sTirtougaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCarracostaLevelUpLearnset[] = {
+static const struct LevelUpMove sCarracostaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sArchenLevelUpLearnset[] = {
+static const struct LevelUpMove sArchenLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sArcheopsLevelUpLearnset[] = {
+static const struct LevelUpMove sArcheopsLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTrubbishLevelUpLearnset[] = {
+static const struct LevelUpMove sTrubbishLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGarbodorLevelUpLearnset[] = {
+static const struct LevelUpMove sGarbodorLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sZoruaLevelUpLearnset[] = {
+static const struct LevelUpMove sZoruaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sZoroarkLevelUpLearnset[] = {
+static const struct LevelUpMove sZoroarkLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMinccinoLevelUpLearnset[] = {
+static const struct LevelUpMove sMinccinoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCinccinoLevelUpLearnset[] = {
+static const struct LevelUpMove sCinccinoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGothitaLevelUpLearnset[] = {
+static const struct LevelUpMove sGothitaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGothoritaLevelUpLearnset[] = {
+static const struct LevelUpMove sGothoritaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGothitelleLevelUpLearnset[] = {
+static const struct LevelUpMove sGothitelleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSolosisLevelUpLearnset[] = {
+static const struct LevelUpMove sSolosisLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDuosionLevelUpLearnset[] = {
+static const struct LevelUpMove sDuosionLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sReuniclusLevelUpLearnset[] = {
+static const struct LevelUpMove sReuniclusLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDucklettLevelUpLearnset[] = {
+static const struct LevelUpMove sDucklettLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSwannaLevelUpLearnset[] = {
+static const struct LevelUpMove sSwannaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVanilliteLevelUpLearnset[] = {
+static const struct LevelUpMove sVanilliteLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVanillishLevelUpLearnset[] = {
+static const struct LevelUpMove sVanillishLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVanilluxeLevelUpLearnset[] = {
+static const struct LevelUpMove sVanilluxeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDeerlingLevelUpLearnset[] = {
+static const struct LevelUpMove sDeerlingLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSawsbuckLevelUpLearnset[] = {
+static const struct LevelUpMove sSawsbuckLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sEmolgaLevelUpLearnset[] = {
+static const struct LevelUpMove sEmolgaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKarrablastLevelUpLearnset[] = {
+static const struct LevelUpMove sKarrablastLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sEscavalierLevelUpLearnset[] = {
+static const struct LevelUpMove sEscavalierLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFoongusLevelUpLearnset[] = {
+static const struct LevelUpMove sFoongusLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAmoongussLevelUpLearnset[] = {
+static const struct LevelUpMove sAmoongussLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFrillishLevelUpLearnset[] = {
+static const struct LevelUpMove sFrillishLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sJellicentLevelUpLearnset[] = {
+static const struct LevelUpMove sJellicentLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAlomomolaLevelUpLearnset[] = {
+static const struct LevelUpMove sAlomomolaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sJoltikLevelUpLearnset[] = {
+static const struct LevelUpMove sJoltikLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGalvantulaLevelUpLearnset[] = {
+static const struct LevelUpMove sGalvantulaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFerroseedLevelUpLearnset[] = {
+static const struct LevelUpMove sFerroseedLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFerrothornLevelUpLearnset[] = {
+static const struct LevelUpMove sFerrothornLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKlinkLevelUpLearnset[] = {
+static const struct LevelUpMove sKlinkLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKlangLevelUpLearnset[] = {
+static const struct LevelUpMove sKlangLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKlinklangLevelUpLearnset[] = {
+static const struct LevelUpMove sKlinklangLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTynamoLevelUpLearnset[] = {
+static const struct LevelUpMove sTynamoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sEelektrikLevelUpLearnset[] = {
+static const struct LevelUpMove sEelektrikLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sEelektrossLevelUpLearnset[] = {
+static const struct LevelUpMove sEelektrossLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sElgyemLevelUpLearnset[] = {
+static const struct LevelUpMove sElgyemLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBeheeyemLevelUpLearnset[] = {
+static const struct LevelUpMove sBeheeyemLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLitwickLevelUpLearnset[] = {
+static const struct LevelUpMove sLitwickLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLampentLevelUpLearnset[] = {
+static const struct LevelUpMove sLampentLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sChandelureLevelUpLearnset[] = {
+static const struct LevelUpMove sChandelureLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAxewLevelUpLearnset[] = {
+static const struct LevelUpMove sAxewLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFraxureLevelUpLearnset[] = {
+static const struct LevelUpMove sFraxureLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHaxorusLevelUpLearnset[] = {
+static const struct LevelUpMove sHaxorusLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCubchooLevelUpLearnset[] = {
+static const struct LevelUpMove sCubchooLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBearticLevelUpLearnset[] = {
+static const struct LevelUpMove sBearticLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCryogonalLevelUpLearnset[] = {
+static const struct LevelUpMove sCryogonalLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sShelmetLevelUpLearnset[] = {
+static const struct LevelUpMove sShelmetLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAccelgorLevelUpLearnset[] = {
+static const struct LevelUpMove sAccelgorLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sStunfiskLevelUpLearnset[] = {
+static const struct LevelUpMove sStunfiskLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMienfooLevelUpLearnset[] = {
+static const struct LevelUpMove sMienfooLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMienshaoLevelUpLearnset[] = {
+static const struct LevelUpMove sMienshaoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDruddigonLevelUpLearnset[] = {
+static const struct LevelUpMove sDruddigonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGolettLevelUpLearnset[] = {
+static const struct LevelUpMove sGolettLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGolurkLevelUpLearnset[] = {
+static const struct LevelUpMove sGolurkLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPawniardLevelUpLearnset[] = {
+static const struct LevelUpMove sPawniardLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBisharpLevelUpLearnset[] = {
+static const struct LevelUpMove sBisharpLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBouffalantLevelUpLearnset[] = {
+static const struct LevelUpMove sBouffalantLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRuffletLevelUpLearnset[] = {
+static const struct LevelUpMove sRuffletLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBraviaryLevelUpLearnset[] = {
+static const struct LevelUpMove sBraviaryLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVullabyLevelUpLearnset[] = {
+static const struct LevelUpMove sVullabyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMandibuzzLevelUpLearnset[] = {
+static const struct LevelUpMove sMandibuzzLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHeatmorLevelUpLearnset[] = {
+static const struct LevelUpMove sHeatmorLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDurantLevelUpLearnset[] = {
+static const struct LevelUpMove sDurantLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDeinoLevelUpLearnset[] = {
+static const struct LevelUpMove sDeinoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sZweilousLevelUpLearnset[] = {
+static const struct LevelUpMove sZweilousLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHydreigonLevelUpLearnset[] = {
+static const struct LevelUpMove sHydreigonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLarvestaLevelUpLearnset[] = {
+static const struct LevelUpMove sLarvestaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVolcaronaLevelUpLearnset[] = {
+static const struct LevelUpMove sVolcaronaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCobalionLevelUpLearnset[] = {
+static const struct LevelUpMove sCobalionLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTerrakionLevelUpLearnset[] = {
+static const struct LevelUpMove sTerrakionLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVirizionLevelUpLearnset[] = {
+static const struct LevelUpMove sVirizionLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTornadusLevelUpLearnset[] = {
+static const struct LevelUpMove sTornadusLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sThundurusLevelUpLearnset[] = {
+static const struct LevelUpMove sThundurusLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sReshiramLevelUpLearnset[] = {
+static const struct LevelUpMove sReshiramLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sZekromLevelUpLearnset[] = {
+static const struct LevelUpMove sZekromLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLandorusLevelUpLearnset[] = {
+static const struct LevelUpMove sLandorusLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKyuremLevelUpLearnset[] = {
+static const struct LevelUpMove sKyuremLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKeldeoLevelUpLearnset[] = {
+static const struct LevelUpMove sKeldeoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMeloettaLevelUpLearnset[] = {
+static const struct LevelUpMove sMeloettaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGenesectLevelUpLearnset[] = {
+static const struct LevelUpMove sGenesectLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sChespinLevelUpLearnset[] = {
+static const struct LevelUpMove sChespinLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sQuilladinLevelUpLearnset[] = {
+static const struct LevelUpMove sQuilladinLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sChesnaughtLevelUpLearnset[] = {
+static const struct LevelUpMove sChesnaughtLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFennekinLevelUpLearnset[] = {
+static const struct LevelUpMove sFennekinLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBraixenLevelUpLearnset[] = {
+static const struct LevelUpMove sBraixenLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDelphoxLevelUpLearnset[] = {
+static const struct LevelUpMove sDelphoxLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFroakieLevelUpLearnset[] = {
+static const struct LevelUpMove sFroakieLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFrogadierLevelUpLearnset[] = {
+static const struct LevelUpMove sFrogadierLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGreninjaLevelUpLearnset[] = {
+static const struct LevelUpMove sGreninjaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBunnelbyLevelUpLearnset[] = {
+static const struct LevelUpMove sBunnelbyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDiggersbyLevelUpLearnset[] = {
+static const struct LevelUpMove sDiggersbyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFletchlingLevelUpLearnset[] = {
+static const struct LevelUpMove sFletchlingLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFletchinderLevelUpLearnset[] = {
+static const struct LevelUpMove sFletchinderLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTalonflameLevelUpLearnset[] = {
+static const struct LevelUpMove sTalonflameLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sScatterbugLevelUpLearnset[] = {
+static const struct LevelUpMove sScatterbugLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSpewpaLevelUpLearnset[] = {
+static const struct LevelUpMove sSpewpaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVivillonLevelUpLearnset[] = {
+static const struct LevelUpMove sVivillonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLitleoLevelUpLearnset[] = {
+static const struct LevelUpMove sLitleoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPyroarLevelUpLearnset[] = {
+static const struct LevelUpMove sPyroarLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFlabebeLevelUpLearnset[] = {
+static const struct LevelUpMove sFlabebeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFloetteLevelUpLearnset[] = {
+static const struct LevelUpMove sFloetteLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFlorgesLevelUpLearnset[] = {
+static const struct LevelUpMove sFlorgesLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSkiddoLevelUpLearnset[] = {
+static const struct LevelUpMove sSkiddoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGogoatLevelUpLearnset[] = {
+static const struct LevelUpMove sGogoatLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPanchamLevelUpLearnset[] = {
+static const struct LevelUpMove sPanchamLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPangoroLevelUpLearnset[] = {
+static const struct LevelUpMove sPangoroLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFurfrouLevelUpLearnset[] = {
+static const struct LevelUpMove sFurfrouLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sEspurrLevelUpLearnset[] = {
+static const struct LevelUpMove sEspurrLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMeowsticLevelUpLearnset[] = {
+static const struct LevelUpMove sMeowsticLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHonedgeLevelUpLearnset[] = {
+static const struct LevelUpMove sHonedgeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDoubladeLevelUpLearnset[] = {
+static const struct LevelUpMove sDoubladeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAegislashLevelUpLearnset[] = {
+static const struct LevelUpMove sAegislashLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSpritzeeLevelUpLearnset[] = {
+static const struct LevelUpMove sSpritzeeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAromatisseLevelUpLearnset[] = {
+static const struct LevelUpMove sAromatisseLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSwirlixLevelUpLearnset[] = {
+static const struct LevelUpMove sSwirlixLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSlurpuffLevelUpLearnset[] = {
+static const struct LevelUpMove sSlurpuffLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sInkayLevelUpLearnset[] = {
+static const struct LevelUpMove sInkayLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMalamarLevelUpLearnset[] = {
+static const struct LevelUpMove sMalamarLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBinacleLevelUpLearnset[] = {
+static const struct LevelUpMove sBinacleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBarbaracleLevelUpLearnset[] = {
+static const struct LevelUpMove sBarbaracleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSkrelpLevelUpLearnset[] = {
+static const struct LevelUpMove sSkrelpLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDragalgeLevelUpLearnset[] = {
+static const struct LevelUpMove sDragalgeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sClauncherLevelUpLearnset[] = {
+static const struct LevelUpMove sClauncherLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sClawitzerLevelUpLearnset[] = {
+static const struct LevelUpMove sClawitzerLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHelioptileLevelUpLearnset[] = {
+static const struct LevelUpMove sHelioptileLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHelioliskLevelUpLearnset[] = {
+static const struct LevelUpMove sHelioliskLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTyruntLevelUpLearnset[] = {
+static const struct LevelUpMove sTyruntLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTyrantrumLevelUpLearnset[] = {
+static const struct LevelUpMove sTyrantrumLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAmauraLevelUpLearnset[] = {
+static const struct LevelUpMove sAmauraLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAurorusLevelUpLearnset[] = {
+static const struct LevelUpMove sAurorusLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSylveonLevelUpLearnset[] = {
+static const struct LevelUpMove sSylveonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHawluchaLevelUpLearnset[] = {
+static const struct LevelUpMove sHawluchaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDedenneLevelUpLearnset[] = {
+static const struct LevelUpMove sDedenneLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCarbinkLevelUpLearnset[] = {
+static const struct LevelUpMove sCarbinkLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGoomyLevelUpLearnset[] = {
+static const struct LevelUpMove sGoomyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSliggooLevelUpLearnset[] = {
+static const struct LevelUpMove sSliggooLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGoodraLevelUpLearnset[] = {
+static const struct LevelUpMove sGoodraLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKlefkiLevelUpLearnset[] = {
+static const struct LevelUpMove sKlefkiLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPhantumpLevelUpLearnset[] = {
+static const struct LevelUpMove sPhantumpLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTrevenantLevelUpLearnset[] = {
+static const struct LevelUpMove sTrevenantLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPumpkabooLevelUpLearnset[] = {
+static const struct LevelUpMove sPumpkabooLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGourgeistLevelUpLearnset[] = {
+static const struct LevelUpMove sGourgeistLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBergmiteLevelUpLearnset[] = {
+static const struct LevelUpMove sBergmiteLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAvaluggLevelUpLearnset[] = {
+static const struct LevelUpMove sAvaluggLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sNoibatLevelUpLearnset[] = {
+static const struct LevelUpMove sNoibatLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sNoivernLevelUpLearnset[] = {
+static const struct LevelUpMove sNoivernLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sXerneasLevelUpLearnset[] = {
+static const struct LevelUpMove sXerneasLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sYveltalLevelUpLearnset[] = {
+static const struct LevelUpMove sYveltalLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sZygardeLevelUpLearnset[] = {
+static const struct LevelUpMove sZygardeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDiancieLevelUpLearnset[] = {
+static const struct LevelUpMove sDiancieLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHoopaLevelUpLearnset[] = {
+static const struct LevelUpMove sHoopaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVolcanionLevelUpLearnset[] = {
+static const struct LevelUpMove sVolcanionLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRowletLevelUpLearnset[] = {
+static const struct LevelUpMove sRowletLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDartrixLevelUpLearnset[] = {
+static const struct LevelUpMove sDartrixLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDecidueyeLevelUpLearnset[] = {
+static const struct LevelUpMove sDecidueyeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLittenLevelUpLearnset[] = {
+static const struct LevelUpMove sLittenLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTorracatLevelUpLearnset[] = {
+static const struct LevelUpMove sTorracatLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sIncineroarLevelUpLearnset[] = {
+static const struct LevelUpMove sIncineroarLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPopplioLevelUpLearnset[] = {
+static const struct LevelUpMove sPopplioLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBrionneLevelUpLearnset[] = {
+static const struct LevelUpMove sBrionneLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPrimarinaLevelUpLearnset[] = {
+static const struct LevelUpMove sPrimarinaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPikipekLevelUpLearnset[] = {
+static const struct LevelUpMove sPikipekLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTrumbeakLevelUpLearnset[] = {
+static const struct LevelUpMove sTrumbeakLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sToucannonLevelUpLearnset[] = {
+static const struct LevelUpMove sToucannonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sYungoosLevelUpLearnset[] = {
+static const struct LevelUpMove sYungoosLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGumshoosLevelUpLearnset[] = {
+static const struct LevelUpMove sGumshoosLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGrubbinLevelUpLearnset[] = {
+static const struct LevelUpMove sGrubbinLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCharjabugLevelUpLearnset[] = {
+static const struct LevelUpMove sCharjabugLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVikavoltLevelUpLearnset[] = {
+static const struct LevelUpMove sVikavoltLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCrabrawlerLevelUpLearnset[] = {
+static const struct LevelUpMove sCrabrawlerLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCrabominableLevelUpLearnset[] = {
+static const struct LevelUpMove sCrabominableLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sOricorioLevelUpLearnset[] = {
+static const struct LevelUpMove sOricorioLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCutieflyLevelUpLearnset[] = {
+static const struct LevelUpMove sCutieflyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRibombeeLevelUpLearnset[] = {
+static const struct LevelUpMove sRibombeeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRockruffLevelUpLearnset[] = {
+static const struct LevelUpMove sRockruffLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLycanrocLevelUpLearnset[] = {
+static const struct LevelUpMove sLycanrocLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWishiwashiLevelUpLearnset[] = {
+static const struct LevelUpMove sWishiwashiLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMareanieLevelUpLearnset[] = {
+static const struct LevelUpMove sMareanieLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sToxapexLevelUpLearnset[] = {
+static const struct LevelUpMove sToxapexLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMudbrayLevelUpLearnset[] = {
+static const struct LevelUpMove sMudbrayLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMudsdaleLevelUpLearnset[] = {
+static const struct LevelUpMove sMudsdaleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDewpiderLevelUpLearnset[] = {
+static const struct LevelUpMove sDewpiderLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAraquanidLevelUpLearnset[] = {
+static const struct LevelUpMove sAraquanidLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFomantisLevelUpLearnset[] = {
+static const struct LevelUpMove sFomantisLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLurantisLevelUpLearnset[] = {
+static const struct LevelUpMove sLurantisLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMorelullLevelUpLearnset[] = {
+static const struct LevelUpMove sMorelullLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sShiinoticLevelUpLearnset[] = {
+static const struct LevelUpMove sShiinoticLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSalanditLevelUpLearnset[] = {
+static const struct LevelUpMove sSalanditLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSalazzleLevelUpLearnset[] = {
+static const struct LevelUpMove sSalazzleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sStuffulLevelUpLearnset[] = {
+static const struct LevelUpMove sStuffulLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBewearLevelUpLearnset[] = {
+static const struct LevelUpMove sBewearLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBounsweetLevelUpLearnset[] = {
+static const struct LevelUpMove sBounsweetLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSteeneeLevelUpLearnset[] = {
+static const struct LevelUpMove sSteeneeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTsareenaLevelUpLearnset[] = {
+static const struct LevelUpMove sTsareenaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sComfeyLevelUpLearnset[] = {
+static const struct LevelUpMove sComfeyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sOranguruLevelUpLearnset[] = {
+static const struct LevelUpMove sOranguruLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPassimianLevelUpLearnset[] = {
+static const struct LevelUpMove sPassimianLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWimpodLevelUpLearnset[] = {
+static const struct LevelUpMove sWimpodLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGolisopodLevelUpLearnset[] = {
+static const struct LevelUpMove sGolisopodLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSandygastLevelUpLearnset[] = {
+static const struct LevelUpMove sSandygastLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPalossandLevelUpLearnset[] = {
+static const struct LevelUpMove sPalossandLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPyukumukuLevelUpLearnset[] = {
+static const struct LevelUpMove sPyukumukuLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sType_NullLevelUpLearnset[] = {
+static const struct LevelUpMove sType_NullLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSilvallyLevelUpLearnset[] = {
+static const struct LevelUpMove sSilvallyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMiniorLevelUpLearnset[] = {
+static const struct LevelUpMove sMiniorLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKomalaLevelUpLearnset[] = {
+static const struct LevelUpMove sKomalaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTurtonatorLevelUpLearnset[] = {
+static const struct LevelUpMove sTurtonatorLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTogedemaruLevelUpLearnset[] = {
+static const struct LevelUpMove sTogedemaruLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMimikyuLevelUpLearnset[] = {
+static const struct LevelUpMove sMimikyuLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBruxishLevelUpLearnset[] = {
+static const struct LevelUpMove sBruxishLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDrampaLevelUpLearnset[] = {
+static const struct LevelUpMove sDrampaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDhelmiseLevelUpLearnset[] = {
+static const struct LevelUpMove sDhelmiseLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sJangmo_oLevelUpLearnset[] = {
+static const struct LevelUpMove sJangmo_oLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHakamo_oLevelUpLearnset[] = {
+static const struct LevelUpMove sHakamo_oLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKommo_oLevelUpLearnset[] = {
+static const struct LevelUpMove sKommo_oLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTapu_KokoLevelUpLearnset[] = {
+static const struct LevelUpMove sTapu_KokoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTapu_LeleLevelUpLearnset[] = {
+static const struct LevelUpMove sTapu_LeleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTapu_BuluLevelUpLearnset[] = {
+static const struct LevelUpMove sTapu_BuluLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTapu_FiniLevelUpLearnset[] = {
+static const struct LevelUpMove sTapu_FiniLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCosmogLevelUpLearnset[] = {
+static const struct LevelUpMove sCosmogLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCosmoemLevelUpLearnset[] = {
+static const struct LevelUpMove sCosmoemLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSolgaleoLevelUpLearnset[] = {
+static const struct LevelUpMove sSolgaleoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLunalaLevelUpLearnset[] = {
+static const struct LevelUpMove sLunalaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sNihilegoLevelUpLearnset[] = {
+static const struct LevelUpMove sNihilegoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBuzzwoleLevelUpLearnset[] = {
+static const struct LevelUpMove sBuzzwoleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPheromosaLevelUpLearnset[] = {
+static const struct LevelUpMove sPheromosaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sXurkitreeLevelUpLearnset[] = {
+static const struct LevelUpMove sXurkitreeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCelesteelaLevelUpLearnset[] = {
+static const struct LevelUpMove sCelesteelaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKartanaLevelUpLearnset[] = {
+static const struct LevelUpMove sKartanaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGuzzlordLevelUpLearnset[] = {
+static const struct LevelUpMove sGuzzlordLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sNecrozmaLevelUpLearnset[] = {
+static const struct LevelUpMove sNecrozmaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMagearnaLevelUpLearnset[] = {
+static const struct LevelUpMove sMagearnaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMarshadowLevelUpLearnset[] = {
+static const struct LevelUpMove sMarshadowLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPoipoleLevelUpLearnset[] = {
+static const struct LevelUpMove sPoipoleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sNaganadelLevelUpLearnset[] = {
+static const struct LevelUpMove sNaganadelLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sStakatakaLevelUpLearnset[] = {
+static const struct LevelUpMove sStakatakaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBlacephalonLevelUpLearnset[] = {
+static const struct LevelUpMove sBlacephalonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sZeraoraLevelUpLearnset[] = {
+static const struct LevelUpMove sZeraoraLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMeltanLevelUpLearnset[] = {
+static const struct LevelUpMove sMeltanLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMelmetalLevelUpLearnset[] = {
+static const struct LevelUpMove sMelmetalLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGrookeyLevelUpLearnset[] = {
+static const struct LevelUpMove sGrookeyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sThwackeyLevelUpLearnset[] = {
+static const struct LevelUpMove sThwackeyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRillaboomLevelUpLearnset[] = {
+static const struct LevelUpMove sRillaboomLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sScorbunnyLevelUpLearnset[] = {
+static const struct LevelUpMove sScorbunnyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRabootLevelUpLearnset[] = {
+static const struct LevelUpMove sRabootLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCinderaceLevelUpLearnset[] = {
+static const struct LevelUpMove sCinderaceLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSobbleLevelUpLearnset[] = {
+static const struct LevelUpMove sSobbleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDrizzileLevelUpLearnset[] = {
+static const struct LevelUpMove sDrizzileLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sInteleonLevelUpLearnset[] = {
+static const struct LevelUpMove sInteleonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSkwovetLevelUpLearnset[] = {
+static const struct LevelUpMove sSkwovetLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGreedentLevelUpLearnset[] = {
+static const struct LevelUpMove sGreedentLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRookideeLevelUpLearnset[] = {
+static const struct LevelUpMove sRookideeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCorvisquireLevelUpLearnset[] = {
+static const struct LevelUpMove sCorvisquireLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCorviknightLevelUpLearnset[] = {
+static const struct LevelUpMove sCorviknightLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBlipbugLevelUpLearnset[] = {
+static const struct LevelUpMove sBlipbugLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDottlerLevelUpLearnset[] = {
+static const struct LevelUpMove sDottlerLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sOrbeetleLevelUpLearnset[] = {
+static const struct LevelUpMove sOrbeetleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sNickitLevelUpLearnset[] = {
+static const struct LevelUpMove sNickitLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sThievulLevelUpLearnset[] = {
+static const struct LevelUpMove sThievulLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGossifleurLevelUpLearnset[] = {
+static const struct LevelUpMove sGossifleurLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sEldegossLevelUpLearnset[] = {
+static const struct LevelUpMove sEldegossLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWoolooLevelUpLearnset[] = {
+static const struct LevelUpMove sWoolooLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDubwoolLevelUpLearnset[] = {
+static const struct LevelUpMove sDubwoolLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sChewtleLevelUpLearnset[] = {
+static const struct LevelUpMove sChewtleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDrednawLevelUpLearnset[] = {
+static const struct LevelUpMove sDrednawLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sYamperLevelUpLearnset[] = {
+static const struct LevelUpMove sYamperLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBoltundLevelUpLearnset[] = {
+static const struct LevelUpMove sBoltundLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRolycolyLevelUpLearnset[] = {
+static const struct LevelUpMove sRolycolyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCarkolLevelUpLearnset[] = {
+static const struct LevelUpMove sCarkolLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCoalossalLevelUpLearnset[] = {
+static const struct LevelUpMove sCoalossalLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sApplinLevelUpLearnset[] = {
+static const struct LevelUpMove sApplinLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFlappleLevelUpLearnset[] = {
+static const struct LevelUpMove sFlappleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAppletunLevelUpLearnset[] = {
+static const struct LevelUpMove sAppletunLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSilicobraLevelUpLearnset[] = {
+static const struct LevelUpMove sSilicobraLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSandacondaLevelUpLearnset[] = {
+static const struct LevelUpMove sSandacondaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCramorantLevelUpLearnset[] = {
+static const struct LevelUpMove sCramorantLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sArrokudaLevelUpLearnset[] = {
+static const struct LevelUpMove sArrokudaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBarraskewdaLevelUpLearnset[] = {
+static const struct LevelUpMove sBarraskewdaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sToxelLevelUpLearnset[] = {
+static const struct LevelUpMove sToxelLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sToxtricityLevelUpLearnset[] = {
+static const struct LevelUpMove sToxtricityLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSizzlipedeLevelUpLearnset[] = {
+static const struct LevelUpMove sSizzlipedeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCentiskorchLevelUpLearnset[] = {
+static const struct LevelUpMove sCentiskorchLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sClobbopusLevelUpLearnset[] = {
+static const struct LevelUpMove sClobbopusLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGrapploctLevelUpLearnset[] = {
+static const struct LevelUpMove sGrapploctLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSinisteaLevelUpLearnset[] = {
+static const struct LevelUpMove sSinisteaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPolteageistLevelUpLearnset[] = {
+static const struct LevelUpMove sPolteageistLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHatennaLevelUpLearnset[] = {
+static const struct LevelUpMove sHatennaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHattremLevelUpLearnset[] = {
+static const struct LevelUpMove sHattremLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHattereneLevelUpLearnset[] = {
+static const struct LevelUpMove sHattereneLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sImpidimpLevelUpLearnset[] = {
+static const struct LevelUpMove sImpidimpLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMorgremLevelUpLearnset[] = {
+static const struct LevelUpMove sMorgremLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGrimmsnarlLevelUpLearnset[] = {
+static const struct LevelUpMove sGrimmsnarlLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sObstagoonLevelUpLearnset[] = {
+static const struct LevelUpMove sObstagoonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPerrserkerLevelUpLearnset[] = {
+static const struct LevelUpMove sPerrserkerLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCursolaLevelUpLearnset[] = {
+static const struct LevelUpMove sCursolaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSirfetchdLevelUpLearnset[] = {
+static const struct LevelUpMove sSirfetchdLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMr_RimeLevelUpLearnset[] = {
+static const struct LevelUpMove sMr_RimeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRunerigusLevelUpLearnset[] = {
+static const struct LevelUpMove sRunerigusLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMilceryLevelUpLearnset[] = {
+static const struct LevelUpMove sMilceryLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAlcremieLevelUpLearnset[] = {
+static const struct LevelUpMove sAlcremieLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFalinksLevelUpLearnset[] = {
+static const struct LevelUpMove sFalinksLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPincurchinLevelUpLearnset[] = {
+static const struct LevelUpMove sPincurchinLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSnomLevelUpLearnset[] = {
+static const struct LevelUpMove sSnomLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFrosmothLevelUpLearnset[] = {
+static const struct LevelUpMove sFrosmothLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sStonjournerLevelUpLearnset[] = {
+static const struct LevelUpMove sStonjournerLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sEiscueLevelUpLearnset[] = {
+static const struct LevelUpMove sEiscueLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sIndeedeeLevelUpLearnset[] = {
+static const struct LevelUpMove sIndeedeeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMorpekoLevelUpLearnset[] = {
+static const struct LevelUpMove sMorpekoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCufantLevelUpLearnset[] = {
+static const struct LevelUpMove sCufantLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCopperajahLevelUpLearnset[] = {
+static const struct LevelUpMove sCopperajahLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDracozoltLevelUpLearnset[] = {
+static const struct LevelUpMove sDracozoltLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sArctozoltLevelUpLearnset[] = {
+static const struct LevelUpMove sArctozoltLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDracovishLevelUpLearnset[] = {
+static const struct LevelUpMove sDracovishLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sArctovishLevelUpLearnset[] = {
+static const struct LevelUpMove sArctovishLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDuraludonLevelUpLearnset[] = {
+static const struct LevelUpMove sDuraludonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDreepyLevelUpLearnset[] = {
+static const struct LevelUpMove sDreepyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDrakloakLevelUpLearnset[] = {
+static const struct LevelUpMove sDrakloakLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDragapultLevelUpLearnset[] = {
+static const struct LevelUpMove sDragapultLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sZacianLevelUpLearnset[] = {
+static const struct LevelUpMove sZacianLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sZamazentaLevelUpLearnset[] = {
+static const struct LevelUpMove sZamazentaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sEternatusLevelUpLearnset[] = {
+static const struct LevelUpMove sEternatusLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKubfuLevelUpLearnset[] = {
+static const struct LevelUpMove sKubfuLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sUrshifuLevelUpLearnset[] = {
+static const struct LevelUpMove sUrshifuLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sZarudeLevelUpLearnset[] = {
+static const struct LevelUpMove sZarudeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRegielekiLevelUpLearnset[] = {
+static const struct LevelUpMove sRegielekiLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRegidragoLevelUpLearnset[] = {
+static const struct LevelUpMove sRegidragoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGlastrierLevelUpLearnset[] = {
+static const struct LevelUpMove sGlastrierLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSpectrierLevelUpLearnset[] = {
+static const struct LevelUpMove sSpectrierLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCalyrexLevelUpLearnset[] = {
+static const struct LevelUpMove sCalyrexLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWyrdeerLevelUpLearnset[] = {
+static const struct LevelUpMove sWyrdeerLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKleavorLevelUpLearnset[] = {
+static const struct LevelUpMove sKleavorLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sUrsalunaLevelUpLearnset[] = {
+static const struct LevelUpMove sUrsalunaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBasculegionLevelUpLearnset[] = {
+static const struct LevelUpMove sBasculegionLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSneaslerLevelUpLearnset[] = {
+static const struct LevelUpMove sSneaslerLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sOverqwilLevelUpLearnset[] = {
+static const struct LevelUpMove sOverqwilLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sEnamorusLevelUpLearnset[] = {
+static const struct LevelUpMove sEnamorusLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSprigatitoLevelUpLearnset[] = {
+static const struct LevelUpMove sSprigatitoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFloragatoLevelUpLearnset[] = {
+static const struct LevelUpMove sFloragatoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMeowscaradaLevelUpLearnset[] = {
+static const struct LevelUpMove sMeowscaradaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFuecocoLevelUpLearnset[] = {
+static const struct LevelUpMove sFuecocoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCrocalorLevelUpLearnset[] = {
+static const struct LevelUpMove sCrocalorLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSkeledirgeLevelUpLearnset[] = {
+static const struct LevelUpMove sSkeledirgeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sQuaxlyLevelUpLearnset[] = {
+static const struct LevelUpMove sQuaxlyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sQuaxwellLevelUpLearnset[] = {
+static const struct LevelUpMove sQuaxwellLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sQuaquavalLevelUpLearnset[] = {
+static const struct LevelUpMove sQuaquavalLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLechonkLevelUpLearnset[] = {
+static const struct LevelUpMove sLechonkLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sOinkologneLevelUpLearnset[] = {
+static const struct LevelUpMove sOinkologneLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTarountulaLevelUpLearnset[] = {
+static const struct LevelUpMove sTarountulaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSpidopsLevelUpLearnset[] = {
+static const struct LevelUpMove sSpidopsLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sNymbleLevelUpLearnset[] = {
+static const struct LevelUpMove sNymbleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLokixLevelUpLearnset[] = {
+static const struct LevelUpMove sLokixLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPawmiLevelUpLearnset[] = {
+static const struct LevelUpMove sPawmiLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPawmoLevelUpLearnset[] = {
+static const struct LevelUpMove sPawmoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPawmotLevelUpLearnset[] = {
+static const struct LevelUpMove sPawmotLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTandemausLevelUpLearnset[] = {
+static const struct LevelUpMove sTandemausLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMausholdLevelUpLearnset[] = {
+static const struct LevelUpMove sMausholdLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFidoughLevelUpLearnset[] = {
+static const struct LevelUpMove sFidoughLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDachsbunLevelUpLearnset[] = {
+static const struct LevelUpMove sDachsbunLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSmolivLevelUpLearnset[] = {
+static const struct LevelUpMove sSmolivLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDollivLevelUpLearnset[] = {
+static const struct LevelUpMove sDollivLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sArbolivaLevelUpLearnset[] = {
+static const struct LevelUpMove sArbolivaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSquawkabillyLevelUpLearnset[] = {
+static const struct LevelUpMove sSquawkabillyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sNacliLevelUpLearnset[] = {
+static const struct LevelUpMove sNacliLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sNaclstackLevelUpLearnset[] = {
+static const struct LevelUpMove sNaclstackLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGarganaclLevelUpLearnset[] = {
+static const struct LevelUpMove sGarganaclLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCharcadetLevelUpLearnset[] = {
+static const struct LevelUpMove sCharcadetLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sArmarougeLevelUpLearnset[] = {
+static const struct LevelUpMove sArmarougeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCeruledgeLevelUpLearnset[] = {
+static const struct LevelUpMove sCeruledgeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTadbulbLevelUpLearnset[] = {
+static const struct LevelUpMove sTadbulbLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBelliboltLevelUpLearnset[] = {
+static const struct LevelUpMove sBelliboltLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWattrelLevelUpLearnset[] = {
+static const struct LevelUpMove sWattrelLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKilowattrelLevelUpLearnset[] = {
+static const struct LevelUpMove sKilowattrelLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMaschiffLevelUpLearnset[] = {
+static const struct LevelUpMove sMaschiffLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMabosstiffLevelUpLearnset[] = {
+static const struct LevelUpMove sMabosstiffLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sShroodleLevelUpLearnset[] = {
+static const struct LevelUpMove sShroodleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGrafaiaiLevelUpLearnset[] = {
+static const struct LevelUpMove sGrafaiaiLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBramblinLevelUpLearnset[] = {
+static const struct LevelUpMove sBramblinLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBrambleghastLevelUpLearnset[] = {
+static const struct LevelUpMove sBrambleghastLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sToedscoolLevelUpLearnset[] = {
+static const struct LevelUpMove sToedscoolLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sToedscruelLevelUpLearnset[] = {
+static const struct LevelUpMove sToedscruelLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKlawfLevelUpLearnset[] = {
+static const struct LevelUpMove sKlawfLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCapsakidLevelUpLearnset[] = {
+static const struct LevelUpMove sCapsakidLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sScovillainLevelUpLearnset[] = {
+static const struct LevelUpMove sScovillainLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRellorLevelUpLearnset[] = {
+static const struct LevelUpMove sRellorLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRabscaLevelUpLearnset[] = {
+static const struct LevelUpMove sRabscaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFlittleLevelUpLearnset[] = {
+static const struct LevelUpMove sFlittleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sEspathraLevelUpLearnset[] = {
+static const struct LevelUpMove sEspathraLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTinkatinkLevelUpLearnset[] = {
+static const struct LevelUpMove sTinkatinkLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTinkatuffLevelUpLearnset[] = {
+static const struct LevelUpMove sTinkatuffLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTinkatonLevelUpLearnset[] = {
+static const struct LevelUpMove sTinkatonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWiglettLevelUpLearnset[] = {
+static const struct LevelUpMove sWiglettLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWugtrioLevelUpLearnset[] = {
+static const struct LevelUpMove sWugtrioLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBombirdierLevelUpLearnset[] = {
+static const struct LevelUpMove sBombirdierLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFinizenLevelUpLearnset[] = {
+static const struct LevelUpMove sFinizenLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPalafinLevelUpLearnset[] = {
+static const struct LevelUpMove sPalafinLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVaroomLevelUpLearnset[] = {
+static const struct LevelUpMove sVaroomLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRevavroomLevelUpLearnset[] = {
+static const struct LevelUpMove sRevavroomLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCyclizarLevelUpLearnset[] = {
+static const struct LevelUpMove sCyclizarLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sOrthwormLevelUpLearnset[] = {
+static const struct LevelUpMove sOrthwormLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGlimmetLevelUpLearnset[] = {
+static const struct LevelUpMove sGlimmetLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGlimmoraLevelUpLearnset[] = {
+static const struct LevelUpMove sGlimmoraLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGreavardLevelUpLearnset[] = {
+static const struct LevelUpMove sGreavardLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHoundstoneLevelUpLearnset[] = {
+static const struct LevelUpMove sHoundstoneLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFlamigoLevelUpLearnset[] = {
+static const struct LevelUpMove sFlamigoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCetoddleLevelUpLearnset[] = {
+static const struct LevelUpMove sCetoddleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCetitanLevelUpLearnset[] = {
+static const struct LevelUpMove sCetitanLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVeluzaLevelUpLearnset[] = {
+static const struct LevelUpMove sVeluzaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDondozoLevelUpLearnset[] = {
+static const struct LevelUpMove sDondozoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTatsugiriLevelUpLearnset[] = {
+static const struct LevelUpMove sTatsugiriLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAnnihilapeLevelUpLearnset[] = {
+static const struct LevelUpMove sAnnihilapeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sClodsireLevelUpLearnset[] = {
+static const struct LevelUpMove sClodsireLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFarigirafLevelUpLearnset[] = {
+static const struct LevelUpMove sFarigirafLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDudunsparceLevelUpLearnset[] = {
+static const struct LevelUpMove sDudunsparceLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKingambitLevelUpLearnset[] = {
+static const struct LevelUpMove sKingambitLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGreat_TuskLevelUpLearnset[] = {
+static const struct LevelUpMove sGreat_TuskLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sScream_TailLevelUpLearnset[] = {
+static const struct LevelUpMove sScream_TailLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBrute_BonnetLevelUpLearnset[] = {
+static const struct LevelUpMove sBrute_BonnetLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFlutter_ManeLevelUpLearnset[] = {
+static const struct LevelUpMove sFlutter_ManeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSlither_WingLevelUpLearnset[] = {
+static const struct LevelUpMove sSlither_WingLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSandy_ShocksLevelUpLearnset[] = {
+static const struct LevelUpMove sSandy_ShocksLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sIron_TreadsLevelUpLearnset[] = {
+static const struct LevelUpMove sIron_TreadsLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sIron_BundleLevelUpLearnset[] = {
+static const struct LevelUpMove sIron_BundleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sIron_HandsLevelUpLearnset[] = {
+static const struct LevelUpMove sIron_HandsLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sIron_JugulisLevelUpLearnset[] = {
+static const struct LevelUpMove sIron_JugulisLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sIron_MothLevelUpLearnset[] = {
+static const struct LevelUpMove sIron_MothLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sIron_ThornsLevelUpLearnset[] = {
+static const struct LevelUpMove sIron_ThornsLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFrigibaxLevelUpLearnset[] = {
+static const struct LevelUpMove sFrigibaxLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sArctibaxLevelUpLearnset[] = {
+static const struct LevelUpMove sArctibaxLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBaxcaliburLevelUpLearnset[] = {
+static const struct LevelUpMove sBaxcaliburLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGimmighoulLevelUpLearnset[] = {
+static const struct LevelUpMove sGimmighoulLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGholdengoLevelUpLearnset[] = {
+static const struct LevelUpMove sGholdengoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWo_ChienLevelUpLearnset[] = {
+static const struct LevelUpMove sWo_ChienLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sChien_PaoLevelUpLearnset[] = {
+static const struct LevelUpMove sChien_PaoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTing_LuLevelUpLearnset[] = {
+static const struct LevelUpMove sTing_LuLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sChi_YuLevelUpLearnset[] = {
+static const struct LevelUpMove sChi_YuLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRoaring_MoonLevelUpLearnset[] = {
+static const struct LevelUpMove sRoaring_MoonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sIron_ValiantLevelUpLearnset[] = {
+static const struct LevelUpMove sIron_ValiantLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKoraidonLevelUpLearnset[] = {
+static const struct LevelUpMove sKoraidonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMiraidonLevelUpLearnset[] = {
+static const struct LevelUpMove sMiraidonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sJigglypuff_AboveLevelUpLearnset[] = {
+static const struct LevelUpMove sJigglypuff_AboveLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTentaquilLevelUpLearnset[] = {
+static const struct LevelUpMove sTentaquilLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMissingnoLevelUpLearnset[] = {
+static const struct LevelUpMove sMissingnoLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKenyaLevelUpLearnset[] = {
+static const struct LevelUpMove sKenyaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHitmonchan_ShitLevelUpLearnset[] = {
+static const struct LevelUpMove sHitmonchan_ShitLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHitmonchinLevelUpLearnset[] = {
+static const struct LevelUpMove sHitmonchinLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTrubbish_HaircutLevelUpLearnset[] = {
+static const struct LevelUpMove sTrubbish_HaircutLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAmpharos_MegaLevelUpLearnset[] = {
+static const struct LevelUpMove sAmpharos_MegaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sYoshiLevelUpLearnset[] = {
+static const struct LevelUpMove sYoshiLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDitto_MewLevelUpLearnset[] = {
+static const struct LevelUpMove sDitto_MewLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sUnown_LossLevelUpLearnset[] = {
+static const struct LevelUpMove sUnown_LossLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMagnaloneLevelUpLearnset[] = {
+static const struct LevelUpMove sMagnaloneLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTyranastarLevelUpLearnset[] = {
+static const struct LevelUpMove sTyranastarLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPokemon_GunLevelUpLearnset[] = {
+static const struct LevelUpMove sPokemon_GunLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPlug_OinkLevelUpLearnset[] = {
+static const struct LevelUpMove sPlug_OinkLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
-static const u16 sPikabluLevelUpLearnset[] = {
+static const struct LevelUpMove sPikabluLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRattata_ShinyLevelUpLearnset[] = {
+static const struct LevelUpMove sRattata_ShinyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_ENDEAVOR),
    	LEVEL_UP_MOVE(1, MOVE_QUICK_ATTACK),
 	LEVEL_UP_END
 };
 
-static const u16 sPikachu_BirthdayLevelUpLearnset[] = {
+static const struct LevelUpMove sPikachu_BirthdayLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMew_AncientLevelUpLearnset[] = {
+static const struct LevelUpMove sMew_AncientLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPikachu_OldLevelUpLearnset[] = {
+static const struct LevelUpMove sPikachu_OldLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGenesect_ShinyLevelUpLearnset[] = {
+static const struct LevelUpMove sGenesect_ShinyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sIron_CleftLevelUpLearnset[] = {
+static const struct LevelUpMove sIron_CleftLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVulpix_AlolaLevelUpLearnset[] = {
+static const struct LevelUpMove sVulpix_AlolaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWeezing_AlolaLevelUpLearnset[] = {
+static const struct LevelUpMove sWeezing_AlolaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sThis_GuyLevelUpLearnset[] = {
+static const struct LevelUpMove sThis_GuyLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSteamboat_WillieLevelUpLearnset[] = {
+static const struct LevelUpMove sSteamboat_WillieLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPidgeot_OldLevelUpLearnset[] = {
+static const struct LevelUpMove sPidgeot_OldLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sStrykeLevelUpLearnset[] = {
+static const struct LevelUpMove sStrykeLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sButterfree_FemaleLevelUpLearnset[] = {
+static const struct LevelUpMove sButterfree_FemaleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPikachu_Fat_GayLevelUpLearnset[] = {
+static const struct LevelUpMove sPikachu_Fat_GayLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTrapinch_PikachuLevelUpLearnset[] = {
+static const struct LevelUpMove sTrapinch_PikachuLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKecleon_SansLevelUpLearnset[] = {
+static const struct LevelUpMove sKecleon_SansLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
 
 
-static const u16 sPorygon_16LevelUpLearnset[] = {
+static const struct LevelUpMove sPorygon_16LevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPorygon_8LevelUpLearnset[] = {
+static const struct LevelUpMove sPorygon_8LevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPorygon_4LevelUpLearnset[] = {
+static const struct LevelUpMove sPorygon_4LevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPorist_GamesLevelUpLearnset[] = {
+static const struct LevelUpMove sPorist_GamesLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMiscarriage_KangaLevelUpLearnset[] = {
+static const struct LevelUpMove sMiscarriage_KangaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGhostLevelUpLearnset[] = {
+static const struct LevelUpMove sGhostLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVenomoth_ATVLevelUpLearnset[] = {
+static const struct LevelUpMove sVenomoth_ATVLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRaticate_AlolaLevelUpLearnset[] = {
+static const struct LevelUpMove sRaticate_AlolaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMultipalLevelUpLearnset[] = {
+static const struct LevelUpMove sMultipalLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDividumLevelUpLearnset[] = {
+static const struct LevelUpMove sDividumLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sExponelleLevelUpLearnset[] = {
+static const struct LevelUpMove sExponelleLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPikachu_Snap_SurfLevelUpLearnset[] = {
+static const struct LevelUpMove sPikachu_Snap_SurfLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPikachu_Snap_BallLevelUpLearnset[] = {
+static const struct LevelUpMove sPikachu_Snap_BallLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPikachu_Snap_FlyingLevelUpLearnset[] = {
+static const struct LevelUpMove sPikachu_Snap_FlyingLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPikachu_Snap_CloseLevelUpLearnset[] = {
+static const struct LevelUpMove sPikachu_Snap_CloseLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRaticate_DeadLevelUpLearnset[] = {
+static const struct LevelUpMove sRaticate_DeadLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sShedinja_ElectricLevelUpLearnset[] = {
+static const struct LevelUpMove sShedinja_ElectricLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDigimonLevelUpLearnset[] = {
+static const struct LevelUpMove sDigimonLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sUnown_NudesLevelUpLearnset[] = {
+static const struct LevelUpMove sUnown_NudesLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPorygon22LevelUpLearnset[] = {
+static const struct LevelUpMove sPorygon22LevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHo_OwOLevelUpLearnset[] = {
+static const struct LevelUpMove sHo_OwOLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRatatattaLevelUpLearnset[] = {
+static const struct LevelUpMove sRatatattaLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBulbasaur_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sBulbasaur_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sIvysaur_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sIvysaur_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVenusaur_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sVenusaur_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCharmander_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sCharmander_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCharmeleon_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sCharmeleon_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCharizard_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sCharizard_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSquirtle_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sSquirtle_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWartortle_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sWartortle_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBlastoise_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sBlastoise_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCaterpie_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sCaterpie_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMetapod_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sMetapod_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sButterfree_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sButterfree_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWeedle_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sWeedle_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKakuna_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sKakuna_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBeedrill_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sBeedrill_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPidgey_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sPidgey_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPidgeotto_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sPidgeotto_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPidgeot_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sPidgeot_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRattata_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sRattata_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRaticate_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sRaticate_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSpearow_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sSpearow_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFearow_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sFearow_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sEkans_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sEkans_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sArbok_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sArbok_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPikachu_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sPikachu_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRaichu_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sRaichu_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSandshrew_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sSandshrew_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSandslash_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sSandslash_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sNidorina_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sNidorina_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sNidoqueen_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sNidoqueen_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sNidorino_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sNidorino_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sNidoking_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sNidoking_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sClefairy_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sClefairy_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sClefable_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sClefable_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVulpix_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sVulpix_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sNinetales_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sNinetales_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sJigglypuff_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sJigglypuff_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWigglytuff_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sWigglytuff_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sZubat_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sZubat_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGolbat_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sGolbat_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sOddish_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sOddish_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGloom_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sGloom_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVileplume_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sVileplume_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sParas_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sParas_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sParasect_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sParasect_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVenonat_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sVenonat_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVenomoth_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sVenomoth_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDiglett_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sDiglett_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDugtrio_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sDugtrio_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMeowth_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sMeowth_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPersian_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sPersian_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPsyduck_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sPsyduck_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGolduck_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sGolduck_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMankey_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sMankey_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPrimeape_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sPrimeape_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGrowlithe_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sGrowlithe_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sArcanine_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sArcanine_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPoliwag_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sPoliwag_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPoliwhirl_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sPoliwhirl_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPoliwrath_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sPoliwrath_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAbra_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sAbra_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKadabra_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sKadabra_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAlakazam_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sAlakazam_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMachop_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sMachop_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMachoke_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sMachoke_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMachamp_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sMachamp_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sBellsprout_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sBellsprout_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWeepinbell_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sWeepinbell_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVictreebel_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sVictreebel_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTentacool_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sTentacool_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTentacruel_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sTentacruel_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGeodude_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sGeodude_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGraveler_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sGraveler_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGolem_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sGolem_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPonyta_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sPonyta_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRapidash_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sRapidash_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSlowpoke_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sSlowpoke_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSlowbro_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sSlowbro_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMagnemite_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sMagnemite_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMagneton_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sMagneton_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFarfetchd_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sFarfetchd_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDoduo_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sDoduo_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDodrio_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sDodrio_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSeel_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sSeel_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDewgong_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sDewgong_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGrimer_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sGrimer_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMuk_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sMuk_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sShellder_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sShellder_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCloyster_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sCloyster_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGastly_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sGastly_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHaunter_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sHaunter_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGengar_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sGengar_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sOnix_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sOnix_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDrowzee_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sDrowzee_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHypno_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sHypno_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKrabby_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sKrabby_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKingler_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sKingler_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVoltorb_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sVoltorb_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sElectrode_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sElectrode_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sExeggcute_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sExeggcute_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sExeggutor_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sExeggutor_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sCubone_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sCubone_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMarowak_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sMarowak_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHitmonlee_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sHitmonlee_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHitmonchan_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sHitmonchan_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLickitung_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sLickitung_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKoffing_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sKoffing_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sWeezing_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sWeezing_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRhyhorn_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sRhyhorn_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sRhydon_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sRhydon_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sChansey_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sChansey_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTangela_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sTangela_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKangaskhan_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sKangaskhan_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sHorsea_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sHorsea_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSeadra_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sSeadra_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGoldeen_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sGoldeen_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSeaking_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sSeaking_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sStaryu_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sStaryu_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sStarmie_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sStarmie_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMrMime_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sMrMime_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sScyther_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sScyther_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sJynx_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sJynx_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sElectabuzz_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sElectabuzz_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMagmar_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sMagmar_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPinsir_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sPinsir_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sTauros_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sTauros_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMagikarp_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sMagikarp_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sGyarados_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sGyarados_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sLapras_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sLapras_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDitto_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sDitto_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sEevee_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sEevee_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sVaporeon_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sVaporeon_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sJolteon_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sJolteon_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sFlareon_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sFlareon_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sPorygon_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sPorygon_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sOmanyte_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sOmanyte_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sOmastar_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sOmastar_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKabuto_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sKabuto_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sKabutops_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sKabutops_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sAerodactyl_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sAerodactyl_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sSnorlax_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sSnorlax_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sArticuno_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sArticuno_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sZapdos_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sZapdos_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMoltres_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sMoltres_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDratini_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sDratini_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDragonair_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sDragonair_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sDragonite_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sDragonite_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };
 
-static const u16 sMewtwo_POKERAPLevelUpLearnset[] = {
+static const struct LevelUpMove sMewtwo_POKERAPLevelUpLearnset[] = {
 	LEVEL_UP_MOVE(1, MOVE_TACKLE),
 	LEVEL_UP_END
 };

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2312,22 +2312,13 @@ static void GiveBoxMonInitialMoveset(struct BoxPokemon *boxMon)
     s32 level = GetLevelFromBoxMonExp(boxMon);
     s32 i;
 
-    for (i = 0; gLevelUpLearnsets[species][i] != LEVEL_UP_END; i++)
+    for (i = 0; gLevelUpLearnsets[species][i].move != LEVEL_UP_MOVE_END; i++)
     {
-        u16 moveLevel;
-        u16 move;
-
-        moveLevel = (gLevelUpLearnsets[species][i] & LEVEL_UP_MOVE_LV);
-        
-        if (moveLevel == 0)
-            continue;    
-        if (moveLevel > (level << 9))
+        if (gLevelUpLearnsets[species][i].level > level)
             break;
 
-        move = (gLevelUpLearnsets[species][i] & LEVEL_UP_MOVE_ID);
-
-        if (GiveMoveToBoxMon(boxMon, move) == MON_HAS_MAX_MOVES)
-            DeleteFirstMoveAndGiveMoveToBoxMon(boxMon, move);
+        if (GiveMoveToBoxMon(boxMon, gLevelUpLearnsets[species][i].move) == MON_HAS_MAX_MOVES)
+            DeleteFirstMoveAndGiveMoveToBoxMon(boxMon, gLevelUpLearnsets[species][i].move);
     }
 }
 
@@ -2343,13 +2334,12 @@ u16 MonTryLearningNewMoveEvolution(struct Pokemon *mon, bool8 firstMove)
     {
         sLearningMoveTableID = 0;
     }
-    while(gLevelUpLearnsets[species][sLearningMoveTableID] != LEVEL_UP_END)
+    while (gLevelUpLearnsets[species][sLearningMoveTableID].move != LEVEL_UP_MOVE_END)
     {
-        u16 moveLevel;
-        moveLevel = (gLevelUpLearnsets[species][sLearningMoveTableID] & 0xFE00);
-        while (moveLevel == 0 || moveLevel == (level << 9))
+        while (gLevelUpLearnsets[species][sLearningMoveTableID].level == 0 
+               || gLevelUpLearnsets[species][sLearningMoveTableID].level  == level)
         {
-            gMoveToLearn = (gLevelUpLearnsets[species][sLearningMoveTableID] & 0x01FF);
+            gMoveToLearn = gLevelUpLearnsets[species][sLearningMoveTableID].move;
             sLearningMoveTableID++;
             return GiveMoveToMon(mon, gMoveToLearn);
         }
@@ -2372,17 +2362,17 @@ u16 MonTryLearningNewMove(struct Pokemon *mon, bool8 firstMove)
     {
         sLearningMoveTableID = 0;
 
-        while ((gLevelUpLearnsets[species][sLearningMoveTableID] & LEVEL_UP_MOVE_LV) != (level << 9))
+        while (gLevelUpLearnsets[species][sLearningMoveTableID].level != level)
         {
             sLearningMoveTableID++;
-            if (gLevelUpLearnsets[species][sLearningMoveTableID] == LEVEL_UP_END)
+            if (gLevelUpLearnsets[species][sLearningMoveTableID].move == LEVEL_UP_MOVE_END)
                 return MOVE_NONE;
         }
     }
 
-    if ((gLevelUpLearnsets[species][sLearningMoveTableID] & LEVEL_UP_MOVE_LV) == (level << 9))
+    if (gLevelUpLearnsets[species][sLearningMoveTableID].level == level)
     {
-        gMoveToLearn = (gLevelUpLearnsets[species][sLearningMoveTableID] & LEVEL_UP_MOVE_ID);
+        gMoveToLearn = gLevelUpLearnsets[species][sLearningMoveTableID].move;
         sLearningMoveTableID++;
         retVal = GiveMoveToMon(mon, gMoveToLearn);
     }
@@ -5837,25 +5827,21 @@ u8 GetMoveRelearnerMoves(struct Pokemon *mon, u16 *moves)
 
     for (i = 0; i < MAX_LEVEL_UP_MOVES; i++)
     {
-        u16 moveLevel;
-
-        if (gLevelUpLearnsets[species][i] == LEVEL_UP_END)
+        if (gLevelUpLearnsets[species][i].move == LEVEL_UP_MOVE_END)
             break;
 
-        moveLevel = gLevelUpLearnsets[species][i] & LEVEL_UP_MOVE_LV;
-
-        if (moveLevel <= (level << 9))
+        if (gLevelUpLearnsets[species][i].level <= level)
         {
-            for (j = 0; j < MAX_MON_MOVES && learnedMoves[j] != (gLevelUpLearnsets[species][i] & LEVEL_UP_MOVE_ID); j++)
+            for (j = 0; j < MAX_MON_MOVES && learnedMoves[j] != gLevelUpLearnsets[species][i].move; j++)
                 ;
 
             if (j == MAX_MON_MOVES)
             {
-                for (k = 0; k < numMoves && moves[k] != (gLevelUpLearnsets[species][i] & LEVEL_UP_MOVE_ID); k++)
+                for (k = 0; k < numMoves && moves[k] != gLevelUpLearnsets[species][i].move; k++)
                     ;
 
                 if (k == numMoves)
-                    moves[numMoves++] = gLevelUpLearnsets[species][i] & LEVEL_UP_MOVE_ID;
+                    moves[numMoves++] = gLevelUpLearnsets[species][i].move;
             }
         }
     }
@@ -5868,8 +5854,8 @@ u8 GetLevelUpMovesBySpecies(u16 species, u16 *moves)
     u8 numMoves = 0;
     int i;
 
-    for (i = 0; i < MAX_LEVEL_UP_MOVES && gLevelUpLearnsets[species][i] != LEVEL_UP_END; i++)
-         moves[numMoves++] = gLevelUpLearnsets[species][i] & LEVEL_UP_MOVE_ID;
+    for (i = 0; i < MAX_LEVEL_UP_MOVES && gLevelUpLearnsets[species][i].move != LEVEL_UP_MOVE_END; i++)
+         moves[numMoves++] = gLevelUpLearnsets[species][i].move;
 
      return numMoves;
 }
@@ -5893,23 +5879,21 @@ u8 GetNumberOfRelearnableMoves(struct Pokemon *mon)
     {
         u16 moveLevel;
 
-        if (gLevelUpLearnsets[species][i] == LEVEL_UP_END)
+        if (gLevelUpLearnsets[species][i].move == LEVEL_UP_MOVE_END)
             break;
 
-        moveLevel = gLevelUpLearnsets[species][i] & LEVEL_UP_MOVE_LV;
-
-        if (moveLevel <= (level << 9))
+        if (gLevelUpLearnsets[species][i].level <= level)
         {
-            for (j = 0; j < MAX_MON_MOVES && learnedMoves[j] != (gLevelUpLearnsets[species][i] & LEVEL_UP_MOVE_ID); j++)
+            for (j = 0; j < MAX_MON_MOVES && learnedMoves[j] != gLevelUpLearnsets[species][i].move; j++)
                 ;
 
             if (j == MAX_MON_MOVES)
             {
-                for (k = 0; k < numMoves && moves[k] != (gLevelUpLearnsets[species][i] & LEVEL_UP_MOVE_ID); k++)
+                for (k = 0; k < numMoves && moves[k] != gLevelUpLearnsets[species][i].move; k++)
                     ;
 
                 if (k == numMoves)
-                    moves[numMoves++] = gLevelUpLearnsets[species][i] & LEVEL_UP_MOVE_ID;
+                    moves[numMoves++] = gLevelUpLearnsets[species][i].move;
             }
         }
     }
@@ -6554,21 +6538,21 @@ void GiveBoxMonInitialMoveset_Fast(struct BoxPokemon *boxMon) //Credit: Asparagu
     u16 levelMoveCount = 0;
     u16 moves[MAX_MON_MOVES] = {0};
     u8 addedMoves = 0;
-    const u16 *learnset = GetSpeciesLevelUpLearnset(species);
+    const struct LevelUpMove *learnset = GetSpeciesLevelUpLearnset(species);
 
-    for (i = 0; learnset[i] != LEVEL_UP_END; i++)
+    for (i = 0; learnset[i].move != LEVEL_UP_MOVE_END; i++)
         levelMoveCount++;
         
     for (i = levelMoveCount; (i >= 0 && addedMoves < MAX_MON_MOVES); i--)
     {
-        if ((learnset[i] & LEVEL_UP_MOVE_LV) > (level << 9))
+        if (learnset[i].level > level)
             continue;
             
-        if ((learnset[i] & LEVEL_UP_MOVE_LV) == 0)
+        if (learnset[i].level == 0)
             continue;
 
-        if (moves[addedMoves] != (learnset[i] & LEVEL_UP_MOVE_ID))
-            moves[addedMoves++] = (learnset[i] & LEVEL_UP_MOVE_ID);
+        if (moves[addedMoves] != learnset[i].move)
+            moves[addedMoves++] = learnset[i].move;
     }
     for (i = MAX_MON_MOVES - 1; i >= 0; i--)
     {
@@ -6577,9 +6561,9 @@ void GiveBoxMonInitialMoveset_Fast(struct BoxPokemon *boxMon) //Credit: Asparagu
     }
 }
 
-const u16 *GetSpeciesLevelUpLearnset(u16 species)
+const struct LevelUpMove *GetSpeciesLevelUpLearnset(u16 species)
 {
-    const u16 *learnset = gLevelUpLearnsets[species];
+    const struct LevelUpMove *learnset = gLevelUpLearnsets[species];
     if (learnset == NULL)
         return gLevelUpLearnsets[SPECIES_NONE];
     return learnset;


### PR DESCRIPTION
Ripped these changes from pokeemerald-expansion. This should make it more straightforward to work with level up moves and remove the issue with move IDs being too high and causing issues.