### PR TITLE
Fix dad heal messing up palettes during weather

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1715,6 +1715,14 @@
 	.2byte \species
 	.endm
 
+	@ Equivalent to fadescreen but copies gPlttBufferUnfaded to gPaletteDecompressionBuffer on the fade out
+	@ and the reverse on the fade in, in effect saving gPlttBufferUnfaded to restore it.
+	@ (ported from pokeemerald)
+	.macro fadescreenswapbuffers mode:req
+	.byte 0xdc
+	.byte \mode
+	.endm
+
 @ Supplementary
 
 	.macro goto_if_unset flag:req, dest:req

--- a/data/maps/ViridianForest/scripts.pory
+++ b/data/maps/ViridianForest/scripts.pory
@@ -73,12 +73,12 @@ script ViridianForest_MapScript_SetObtainable {
 }
 
 script EventScript_DadHeal {
-	fadescreen(FADE_TO_BLACK)
+	fadescreenswapbuffers(FADE_TO_BLACK)
 	closemessage
 	playfanfare(MUS_HEAL)
 	waitfanfare
 	special(HealPlayerParty)
-	fadescreen(FADE_FROM_BLACK)
+	fadescreenswapbuffers(FADE_FROM_BLACK)
 	msgbox(("DAD: There!\nBest of luck to you!"), MSGBOX_DEFAULT)
 	return
 }

--- a/data/script_cmd_table.inc
+++ b/data/script_cmd_table.inc
@@ -221,6 +221,7 @@ gScriptCmdTable::
 	.4byte ScrCmd_dynmultipush                   @ 0xd9
 	.4byte ScrCmd_setobtainable           		 @ 0xda
 	.4byte ScrCmd_checkmoncaught           		 @ 0xdb
+	.4byte ScrCmd_fadescreenswapbuffers    		 @ 0xdc
 
 gScriptCmdTableEnd::
 	.4byte ScrCmd_nop

--- a/include/palette.h
+++ b/include/palette.h
@@ -59,6 +59,7 @@ extern struct PaletteFadeControl gPaletteFade;
 extern u32 gPlttBufferTransferPending;
 extern u16 gPlttBufferUnfaded[PLTT_BUFFER_SIZE];
 extern u16 gPlttBufferFaded[PLTT_BUFFER_SIZE];
+extern u8 gPaletteDecompressionBuffer[PLTT_SIZE];
 
 void LoadCompressedPalette(const u32 *src, u16 offset, u16 size);
 void LoadPalette(const void *src, u16 offset, u16 size);

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -634,6 +634,29 @@ bool8 ScrCmd_fadescreen(struct ScriptContext * ctx)
     return TRUE;
 }
 
+bool8 ScrCmd_fadescreenswapbuffers(struct ScriptContext *ctx)
+{
+    u8 mode = ScriptReadByte(ctx);
+
+    switch (mode)
+    {
+    case FADE_TO_BLACK:
+    case FADE_TO_WHITE:
+    default:
+        CpuCopy32(gPlttBufferUnfaded, gPaletteDecompressionBuffer, PLTT_SIZE);
+        FadeScreen(mode, 0);
+        break;
+    case FADE_FROM_BLACK:
+    case FADE_FROM_WHITE:
+        CpuCopy32(gPaletteDecompressionBuffer, gPlttBufferUnfaded, PLTT_SIZE);
+        FadeScreen(mode, 0);
+        break;
+    }
+
+    SetupNativeScript(ctx, IsPaletteNotActive);
+    return TRUE;
+}
+
 bool8 ScrCmd_fadescreenspeed(struct ScriptContext * ctx)
 {
     u8 mode = ScriptReadByte(ctx);


### PR DESCRIPTION
This fixes the Dad heal script messing up the palette permanently during weather. It ports a script command from Emerald that GF used in a very similar scenario - it stores the original palette temporarily in the palette decompression buffer, and then restores it after fading back in.