### PR TITLE
Implement release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,11 @@ endif
 ROM := poke$(BUILD_NAME).gba
 OBJ_DIR := $(BUILD_DIR)/$(BUILD_NAME)
 
+ifeq ($(RELEASE), 1)
+ROM := poke$(BUILD_NAME)_release.gba
+OBJ_DIR := $(BUILD_DIR)/$(BUILD_NAME)_release
+endif
+
 ELF := $(ROM:.gba=.elf)
 MAP := $(ROM:.gba=.map)
 SYM := $(ROM:.gba=.sym)
@@ -103,6 +108,11 @@ ifeq ($(DINFO),1)
   override CFLAGS += -g
 endif
 
+ifeq ($(RELEASE),1)
+  override CPPFLAGS += -DRELEASE=$(RELEASE)
+  override ASFLAGS += --defsym RELEASE=$(RELEASE)
+endif
+
 # Variable filled out in other make files
 AUTO_GEN_TARGETS :=
 include make_tools.mk
@@ -130,11 +140,11 @@ MAKEFLAGS += --no-print-directory
 # Delete files that weren't built properly
 .DELETE_ON_ERROR:
 
-ALL_BUILDS := firered firered_rev1 leafgreen leafgreen_rev1
+ALL_BUILDS := firered firered_rev1 leafgreen leafgreen_rev1 firered_release
 ALL_BUILDS += $(ALL_BUILDS:%=%_modern)
 
 RULES_NO_SCAN += clean clean-assets tidy generated clean-generated
-.PHONY: all rom modern compare $(ALL_BUILDS) $(ALL_BUILDS:%=compare_%)
+.PHONY: all rom modern compare release $(ALL_BUILDS) $(ALL_BUILDS:%=compare_%)
 .PHONY: $(RULES_NO_SCAN)
 
 infoshell = $(foreach line, $(shell $1 | sed "s/ /__SPACE__/g"), $(info $(subst __SPACE__, ,$(line))))
@@ -199,6 +209,7 @@ $(shell mkdir -p $(SUBDIRS))
 # Pretend rules that are actually flags defer to `make all`
 modern: all
 compare: all
+release: all
 
 # Other rules
 rom: $(ROM)

--- a/config.mk
+++ b/config.mk
@@ -11,11 +11,17 @@ COMPARE       ?= 0
 
 KEEP_TEMPS    ?= 0
 
+# Release build - turn off debugging
+RELEASE       ?= 0
+
 ifeq (modern,$(MAKECMDGOALS))
   MODERN := 1
 endif
 ifeq (compare,$(MAKECMDGOALS))
   COMPARE := 1
+endif
+ifeq (release,$(MAKECMDGOALS))
+  RELEASE := 1
 endif
 
 # For gbafix

--- a/data/event_scripts.s
+++ b/data/event_scripts.s
@@ -810,7 +810,9 @@ gStdScriptsEnd::
 
 	.include "data/scripts/std_msgbox.inc"
 	.include "data/scripts/trainer_battle.inc"
+.ifndef RELEASE
 	.include "data/scripts/debug.inc"
+.endif
 
 @ Unused
 Text_WouldYouLikeToMixRecords::

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -1,4 +1,3 @@
-.if DEBUG_OVERWORLD_MENU == TRUE
 Debug_MessageEnd:
 	waitmessage
 	waitbuttonpress
@@ -200,5 +199,3 @@ DebugText_DaycareOnePokemon:
 
 DebugText_DaycarePokemonNotCompatible:
 	.string "Your Pokémon at Daycare can't\nhave babies together!$"
-
-.endif

--- a/include/battle_debug.h
+++ b/include/battle_debug.h
@@ -3,6 +3,10 @@
 
 void CB2_BattleDebugMenu(void);
 
+#ifdef RELEASE
+#define DEBUG_BATTLE_MENU               FALSE    // If set to TRUE, enables a debug menu to use in battles by pressing the Select button.
+#else
 #define DEBUG_BATTLE_MENU               TRUE    // If set to TRUE, enables a debug menu to use in battles by pressing the Select button.
+#endif
 
 #endif // GUARD_BATTLE_DEBUG_H

--- a/include/config.h
+++ b/include/config.h
@@ -8,10 +8,13 @@
 // still has them in the ROM. This is because the developers forgot
 // to define NDEBUG before release, however this has been changed as
 // Ruby's actual debug build does not use the AGBPrint features.
-// #define NDEBUG
+#ifdef RELEASE
+#define NDEBUG
+#endif
 
 // Fire Red likely forgot to define NDEBUG/NOAGBPRN before release, leading
 // to the inclusion of asserts in the retail ROM.
+// note: we here at CSR are smarter than GF, please clap
 
 #ifndef NDEBUG
 #define PRETTY_PRINT_OFF (0)

--- a/include/config/debug.h
+++ b/include/config/debug.h
@@ -2,7 +2,12 @@
 #define GUARD_CONFIG_DEBUG_H
 
 // Overworld Debug
+#ifdef RELEASE
+#define DEBUG_OVERWORLD_MENU            FALSE                // Enables an overworld debug menu to change flags, variables, giving pokemon and more, accessed by holding R and pressing START while in the overworld by default.
+#else
 #define DEBUG_OVERWORLD_MENU            TRUE                // Enables an overworld debug menu to change flags, variables, giving pokemon and more, accessed by holding R and pressing START while in the overworld by default.
+#endif
+
 #define DEBUG_OVERWORLD_HELD_KEYS       (R_BUTTON)          // The keys required to be held to open the debug menu.
 #define DEBUG_OVERWORLD_TRIGGER_EVENT   pressedStartButton  // The event that opens the menu when holding the key(s) defined in DEBUG_OVERWORLD_HELD_KEYS.
 #define DEBUG_OVERWORLD_IN_MENU         TRUE                // Replaces the overworld debug menu button combination with a start menu entry (above Pokédex)

--- a/include/constants/pokemon_debug.h
+++ b/include/constants/pokemon_debug.h
@@ -41,6 +41,10 @@
 #define MAP_BATTLE_SCENE_CHAMPION     10
 
 // enable debug menu
+#ifdef RELEASE
+#define DEBUG_POKEMON_MENU            FALSE
+#else
 #define DEBUG_POKEMON_MENU            TRUE
+#endif
 
 #endif // GUARD_CONSTANTS_POKEMON_DEBUG_H


### PR DESCRIPTION
This adds a release target to the Makefile so we can easily build the ROM without any debugging features built in. When `RELEASE` is enabled, all of the debug menus are disabled and any debug prints are turned off.

 To build a release, simply use:
 ```bash
 make release
 ```
 instead of your regularly scheduled `make`. Just like with normal `make` you can (and should) use `-j`.
 
 Note that when you build a release, it will create a different ROM called `pokefirered_release.gba`, not just `pokefirered`.