### PR TITLE
Free up unused save space and reserve it for future releases

### DIFF
--- a/include/constants/global.h
+++ b/include/constants/global.h
@@ -33,8 +33,8 @@
 // capacities of various saveblock objects
 #define DAYCARE_MON_COUNT   2
 #define PC_ITEMS_COUNT      30
-#define BAG_ITEMS_COUNT     42
-#define BAG_KEYITEMS_COUNT  30
+#define BAG_ITEMS_COUNT     52
+#define BAG_KEYITEMS_COUNT  40
 #define BAG_POKEBALLS_COUNT 13
 #define BAG_TMHM_COUNT      58
 #define BAG_BERRIES_COUNT   43

--- a/include/constants/pokedex.h
+++ b/include/constants/pokedex.h
@@ -479,7 +479,8 @@ enum {
 
 #define KANTO_DEX_COUNT     NATIONAL_DEX_CASTFORM
 #define JOHTO_DEX_COUNT     NATIONAL_DEX_SCIZOR
-#define NATIONAL_DEX_COUNT  NATIONAL_DEX_RATTATA_SHINY
+// #define NATIONAL_DEX_COUNT  NATIONAL_DEX_RATTATA_SHINY
+#define NATIONAL_DEX_COUNT  386 // placeholder to reserve space for the future
 
 // Hoenn Pokedex order
 enum {

--- a/include/global.h
+++ b/include/global.h
@@ -209,7 +209,7 @@ struct Pokedex
     /*0x0C*/ u32 unknown3;
     /*0x10*/ u8 owned[DEX_FLAGS_NO];
     /*0x44*/ u8 seen[DEX_FLAGS_NO];
-    /*0x57*/ u8 obtainable[KANTO_DEX_FLAGS_NO];
+    /*0x57*/ u8 obtainable[DEX_FLAGS_NO];
 };
 
 struct PokemonJumpRecords
@@ -351,20 +351,17 @@ struct SaveBlock2
               u16 optionsBattleSceneOff:1; // whether battle animations are disabled
               u16 regionMapZoom:1; // whether the map is zoomed in
     /*0x018*/ struct Pokedex pokedex;
-    /*0x090*/ u8 filler_90[0x8];
     /*0x098*/ struct Time localTimeOffset;
     /*0x0A0*/ struct Time lastBerryTreeUpdate;
     /*0x0A8*/ u32 gcnLinkFlags; // Read by Pokemon Colosseum/XD
-    /*0x0AC*/ bool8 unkFlag1; // Set TRUE, never read
-    /*0x0AD*/ bool8 unkFlag2; // Set FALSE, never read
     /*0x0B0*/ struct BattleTowerData battleTower;
     /*0x898*/ u16 mapView[0x100];
     /*0xA98*/ struct LinkBattleRecords linkBattleRecords;
     /*0xAF0*/ struct BerryCrush berryCrush;
     /*0xB00*/ struct PokemonJumpRecords pokeJump;
     /*0xB10*/ struct BerryPickingResults berryPick;
-    /*0xB20*/ u8 filler_B20[0x400];
     /*0xF20*/ u32 encryptionKey;
+              u8 spaceReserveCSR[1084];
 }; // size: 0xF24
 
 extern struct SaveBlock2 *gSaveBlock2Ptr;
@@ -789,15 +786,14 @@ struct SaveBlock1
     /*0x0430*/ struct ItemSlot bagPocket_PokeBalls[BAG_POKEBALLS_COUNT];
     /*0x0464*/ struct ItemSlot bagPocket_TMHM[BAG_TMHM_COUNT];
     /*0x054c*/ struct ItemSlot bagPocket_Berries[BAG_BERRIES_COUNT];
-    /*0x05F8*/ u8 seen1[DEX_FLAGS_NO];
-    /*0x062C*/ u16 berryBlenderRecords[3]; // unused
-    /*0x0632*/ u8 unused_632[6];
     /*0x0638*/ u16 trainerRematchStepCounter;
     /*0x063A*/ u8 ALIGNED(2) trainerRematches[MAX_REMATCH_ENTRIES];
     /*0x06A0*/ struct ObjectEvent objectEvents[OBJECT_EVENTS_COUNT];
     /*0x08E0*/ struct ObjectEventTemplate objectEventTemplates[OBJECT_EVENT_TEMPLATES_COUNT];
     /*0x0EE0*/ u8 flags[NUM_FLAG_BYTES];
+               u8 flagsReserveCSR[25]; // space for 200 more flags
     /*0x1000*/ u16 vars[VARS_COUNT];
+               u16 varsReserveCSR[10];
     /*0x1200*/ u32 gameStats[NUM_GAME_STATS];
     /*0x1300*/ struct QuestLogScene questLog[QUEST_LOG_SCENE_COUNT];
     /*0x2CA0*/ u16 easyChatProfile[EASY_CHAT_BATTLE_WORDS_COUNT];
@@ -806,8 +802,6 @@ struct SaveBlock1
     /*0x2CC4*/ u16 easyChatBattleLost[EASY_CHAT_BATTLE_WORDS_COUNT];
     /*0x2CD0*/ struct Mail mail[MAIL_COUNT];
     /*0x2F10*/ u8 additionalPhrases[NUM_ADDITIONAL_PHRASE_BYTES];
-    /*0x2F18*/ OldMan oldMan; // unused
-    /*0x2F54*/ struct DewfordTrend dewfordTrends[5]; // unused
     /*0x2F80*/ struct DayCare daycare;
     /*0x309C*/ u8 giftRibbons[GIFT_RIBBONS_COUNT];
     /*0x30A7*/ struct ExternalEventData externalEventData;
@@ -815,21 +809,16 @@ struct SaveBlock1
     /*0x30D0*/ struct Roamer roamer;
     /*0x30EC*/ struct EnigmaBerry enigmaBerry;
     /*0x3120*/ struct MysteryGiftSave mysteryGift;
-    /*0x348C*/ u8 unused_348C[400];
-    /*0x361C*/ struct RamScript ramScript;
-    /*0x3A08*/ struct RecordMixingGift recordMixingGift; // unused
-    /*0x3A18*/ u8 seen2[DEX_FLAGS_NO];
     /*0x3A4C*/ u8 rivalName[PLAYER_NAME_LENGTH + 1];
     /*0x3A54*/ struct FameCheckerSaveData fameChecker[NUM_FAMECHECKER_PERSONS];
-    /*0x3A94*/ u8 unused_3A94[64];
-    /*0x3AD4*/ u8 registeredTexts[UNION_ROOM_KB_ROW_COUNT][21];
+               u8 fameCheckerReserveCSR[20];
     /*0x3BA8*/ struct TrainerNameRecord trainerNameRecords[20];
     /*0x3C98*/ struct DaycareMon route5DayCareMon;
-    /*0x3D24*/ u8 unused_3D24[15];
     /*0x3D24*/ u8 currentOutfit;
     /*0x3D34*/ u32 towerChallengeId;
     /*0x3D38*/ struct TrainerTower trainerTower[NUM_TOWER_CHALLENGE_TYPES];
     /*0x3D50*/ struct WarpData lastBenchLocation;
+               u8 spaceReserveCSR[1920];
 }; // size: 0x3D68
 
 struct MapPosition

--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -475,7 +475,6 @@ static const u8 *GetInteractedObjectEventScript(struct MapPosition *position, u8
 
     script = GetObjectEventScriptPointerByObjectEventId(objectEventId);
 
-    script = GetRamScript(gSpecialVar_LastTalked, script);
     return script;
 }
 

--- a/src/new_game.c
+++ b/src/new_game.c
@@ -121,8 +121,6 @@ void NewGameInitData(void)
     ClearMailData();
     gSaveBlock2Ptr->specialSaveWarpFlags = 0;
     gSaveBlock2Ptr->gcnLinkFlags = 0;
-    gSaveBlock2Ptr->unkFlag1 = TRUE;
-    gSaveBlock2Ptr->unkFlag2 = FALSE;
     InitPlayerTrainerId();
     PlayTimeCounter_Reset();
     ClearPokedexFlags();

--- a/src/pokedex_screen.c
+++ b/src/pokedex_screen.c
@@ -2387,22 +2387,11 @@ s8 DexScreen_GetSetPokedexFlag(u16 nationalDexNo, u8 caseId, bool8 indexIsSpecie
     {
     case FLAG_GET_SEEN:
         if (gSaveBlock2Ptr->pokedex.seen[index] & mask)
-        {
-            // Anticheat
-            if ((gSaveBlock2Ptr->pokedex.seen[index] & mask) == (gSaveBlock1Ptr->seen1[index] & mask)
-                && (gSaveBlock2Ptr->pokedex.seen[index] & mask) == (gSaveBlock1Ptr->seen2[index] & mask))
-                retVal = 1;
-        }
+            retVal = 1;
         break;
     case FLAG_GET_CAUGHT:
         if (gSaveBlock2Ptr->pokedex.owned[index] & mask)
-        {
-            // Anticheat
-            if ((gSaveBlock2Ptr->pokedex.owned[index] & mask) == (gSaveBlock2Ptr->pokedex.seen[index] & mask)
-                && (gSaveBlock2Ptr->pokedex.owned[index] & mask) == (gSaveBlock1Ptr->seen1[index] & mask)
-                && (gSaveBlock2Ptr->pokedex.owned[index] & mask) == (gSaveBlock1Ptr->seen2[index] & mask))
-                retVal = 1;
-        }
+            retVal = 1;
         break;
     case FLAG_GET_OBTAINABLE:
         if (gSaveBlock2Ptr->pokedex.obtainable[index] & mask)
@@ -2410,9 +2399,6 @@ s8 DexScreen_GetSetPokedexFlag(u16 nationalDexNo, u8 caseId, bool8 indexIsSpecie
         break;
     case FLAG_SET_SEEN:
         gSaveBlock2Ptr->pokedex.seen[index] |= mask;
-        // Anticheat
-        gSaveBlock1Ptr->seen1[index] |= mask;
-        gSaveBlock1Ptr->seen2[index] |= mask;
         break;
     case FLAG_SET_CAUGHT:
         gSaveBlock2Ptr->pokedex.owned[index] |= mask;

--- a/src/rom_header_gf.c
+++ b/src/rom_header_gf.c
@@ -25,8 +25,6 @@ struct GFRomHeader
     u32 flagsOffset;
     u32 varsOffset;
     u32 pokedexOffset;
-    u32 seen1Offset;
-    u32 seen2Offset;
     u32 pokedexVar;
     u32 pokedexFlag;
     u32 mysteryGiftFlag;
@@ -56,8 +54,6 @@ struct GFRomHeader
     u32 trainerIdOffset;
     u32 playerNameOffset;
     u32 playerGenderOffset;
-    u32 unkFlagOffset;
-    u32 unkFlagOffset2;
     u32 externalEventFlagsOffset;
     u32 externalEventDataOffset;
     u32 unk18;
@@ -109,8 +105,6 @@ static const struct GFRomHeader sGFRomHeader = {
     .flagsOffset = offsetof(struct SaveBlock1, flags),
     .varsOffset = offsetof(struct SaveBlock1, vars),
     .pokedexOffset = offsetof(struct SaveBlock2, pokedex),
-    .seen1Offset = offsetof(struct SaveBlock1, seen1),
-    .seen2Offset = offsetof(struct SaveBlock1, seen2),
     .pokedexVar = VAR_0x403C - VARS_START,
     .pokedexFlag = FLAG_0x838,
     .mysteryGiftFlag = FLAG_SYS_MYSTERY_GIFT_ENABLED,
@@ -141,8 +135,6 @@ static const struct GFRomHeader sGFRomHeader = {
     .trainerIdOffset = offsetof(struct SaveBlock2, playerTrainerId),
     .playerNameOffset = offsetof(struct SaveBlock2, playerName),
     .playerGenderOffset = offsetof(struct SaveBlock2, playerGender),
-    .unkFlagOffset = offsetof(struct SaveBlock2, unkFlag2),
-    .unkFlagOffset2 = offsetof(struct SaveBlock2, unkFlag2),
     .externalEventFlagsOffset = offsetof(struct SaveBlock1, externalEventFlags),
     .externalEventDataOffset = offsetof(struct SaveBlock1, externalEventData),
     .unk18 = 0x00000000,

--- a/src/script.c
+++ b/src/script.c
@@ -492,101 +492,39 @@ void TryRunOnWarpIntoMapScript(void)
         RunScriptImmediately(ptr);
 }
 
+// CSR note:
+// the ram script code has been massacred for save space
+// it will definitely not work
+
 u32 CalculateRamScriptChecksum(void)
 {
-    return CalcCRC16WithTable((u8 *)(&gSaveBlock1Ptr->ramScript.data), sizeof(gSaveBlock1Ptr->ramScript.data));
+    return 0;
 }
 
 void ClearRamScript(void)
 {
-    CpuFill32(0, &gSaveBlock1Ptr->ramScript, sizeof(struct RamScript));
 }
 
 bool8 InitRamScript(u8 *script, u16 scriptSize, u8 mapGroup, u8 mapNum, u8 objectId)
 {
-    struct RamScriptData *scriptData = &gSaveBlock1Ptr->ramScript.data;
-
-    ClearRamScript();
-
-    if (scriptSize > sizeof(scriptData->script))
-        return FALSE;
-
-    scriptData->magic = RAM_SCRIPT_MAGIC;
-    scriptData->mapGroup = mapGroup;
-    scriptData->mapNum = mapNum;
-    scriptData->objectId = objectId;
-    memcpy(scriptData->script, script, scriptSize);
-    gSaveBlock1Ptr->ramScript.checksum = CalculateRamScriptChecksum();
-    return TRUE;
+    return FALSE;
 }
 
 const u8 *GetRamScript(u8 objectId, const u8 *script)
 {
-    struct RamScriptData *scriptData = &gSaveBlock1Ptr->ramScript.data;
-    gRamScriptRetAddr = NULL;
-    if (scriptData->magic != RAM_SCRIPT_MAGIC)
-        return script;
-    if (scriptData->mapGroup != gSaveBlock1Ptr->location.mapGroup)
-        return script;
-    if (scriptData->mapNum != gSaveBlock1Ptr->location.mapNum)
-        return script;
-    if (scriptData->objectId != objectId)
-        return script;
-    if (CalculateRamScriptChecksum() != gSaveBlock1Ptr->ramScript.checksum)
-    {
-        ClearRamScript();
-        return script;
-    }
-    else
-    {
-        gRamScriptRetAddr = script;
-        return scriptData->script;
-    }
+    return NULL;
 }
 
 bool32 ValidateRamScript(void)
 {
-    struct RamScriptData *scriptData = &gSaveBlock1Ptr->ramScript.data;
-    if (scriptData->magic != RAM_SCRIPT_MAGIC)
-        return FALSE;
-    if (scriptData->mapGroup != MAP_GROUP(UNDEFINED))
-        return FALSE;
-    if (scriptData->mapNum != MAP_NUM(UNDEFINED))
-        return FALSE;
-    if (scriptData->objectId != 0xFF)
-        return FALSE;
-    if (CalculateRamScriptChecksum() != gSaveBlock1Ptr->ramScript.checksum)
-        return FALSE;
-    return TRUE;
+    return FALSE;
 }
 
 u8 *GetSavedRamScriptIfValid(void)
 {
-    struct RamScriptData *scriptData = &gSaveBlock1Ptr->ramScript.data;
-    if (!ValidateSavedWonderCard())
-        return NULL;
-    if (scriptData->magic != RAM_SCRIPT_MAGIC)
-        return NULL;
-    if (scriptData->mapGroup != MAP_GROUP(UNDEFINED))
-        return NULL;
-    if (scriptData->mapNum != MAP_NUM(UNDEFINED))
-        return NULL;
-    if (scriptData->objectId != 0xFF)
-        return NULL;
-    if (CalculateRamScriptChecksum() != gSaveBlock1Ptr->ramScript.checksum)
-    {
-        ClearRamScript();
-        return NULL;
-    }
-    else
-    {
-        return scriptData->script;
-    }
+    return NULL;
 }
 
 void InitRamScript_NoObjectEvent(u8 *script, u16 scriptSize)
 {
-    if (scriptSize > sizeof(gSaveBlock1Ptr->ramScript.data.script))
-        scriptSize = sizeof(gSaveBlock1Ptr->ramScript.data.script);
-    InitRamScript(script, scriptSize, MAP_GROUP(UNDEFINED), MAP_NUM(UNDEFINED), 0xFF);
 }

--- a/src/union_room_chat.c
+++ b/src/union_room_chat.c
@@ -1,3 +1,6 @@
+// CSR note:
+// this code has been massacred for save space
+// it will definitely not work
 #include "global.h"
 #include "gflib.h"
 #include "dynamic_placeholder_text_util.h"
@@ -66,7 +69,6 @@ struct UnionRoomChat
     u8 messageEntryBuffer[2 * MESSAGE_BUFFER_NCHAR + 1];
     u8 receivedMessage[0x40];
     u8 hostName[0x40];
-    u8 registeredTexts[UNION_ROOM_KB_ROW_COUNT][21];
     u8 filler18B[0x5];
     u8 sendMessageBuffer[0x28];
 };
@@ -342,8 +344,6 @@ static void InitChatWork(struct UnionRoomChat * unionRoomChat)
     unionRoomChat->exitType = 0;
     unionRoomChat->changedRegisteredTexts = FALSE;
     PrepareSendBuffer_Null(unionRoomChat->sendMessageBuffer);
-    for (i = 0; i < UNION_ROOM_KB_ROW_COUNT; i++)
-        StringCopy(unionRoomChat->registeredTexts[i], gSaveBlock1Ptr->registeredTexts[i]);
 }
 
 static void FreeChatWork(void)
@@ -1093,9 +1093,6 @@ static void AppendCharacterToChatMessageBuffer(void)
     }
     else
     {
-        u8 *tempStr = StringCopy(buffer, sWork->registeredTexts[sWork->currentRow]);
-        tempStr[0] = CHAR_SPACE;
-        tempStr[1] = EOS;
         charsStr = buffer;
         strLength = StringLength_Multibyte(buffer);
     }
@@ -1161,7 +1158,6 @@ static bool32 ChatMsgHasAtLeastOneCharcter(void)
 static void RegisterTextAtRow(void)
 {
     u8 *src = UnionRoomChat_GetEndOfMessageEntryBuffer();
-    StringCopy(sWork->registeredTexts[sWork->currentRow], src);
     sWork->changedRegisteredTexts = TRUE;
 }
 
@@ -1175,13 +1171,11 @@ static void ResetMessageEntryBuffer(void)
 static void SaveRegisteredTextsToSB1(void)
 {
     int i;
-    for (i = 0; i < UNION_ROOM_KB_ROW_COUNT; i++)
-        StringCopy(gSaveBlock1Ptr->registeredTexts[i], sWork->registeredTexts[i]);
 }
 
 u8 *UnionRoomChat_GetWorkRegisteredText(int arg0)
 {
-    return sWork->registeredTexts[arg0];
+    return 0;
 }
 
 static u8 *GetEndOfUnk1A(void)
@@ -1422,16 +1416,6 @@ u8 *UnionRoomChat_GetNameOfPlayerWhoDisbandedChat(void)
 
 void UnionRoomChat_InitializeRegisteredTexts(void)
 {
-    StringCopy(gSaveBlock1Ptr->registeredTexts[0], gText_Hello);
-    StringCopy(gSaveBlock1Ptr->registeredTexts[1], gText_Pokemon2);
-    StringCopy(gSaveBlock1Ptr->registeredTexts[2], gText_Trade);
-    StringCopy(gSaveBlock1Ptr->registeredTexts[3], gText_Battle);
-    StringCopy(gSaveBlock1Ptr->registeredTexts[4], gText_Lets);
-    StringCopy(gSaveBlock1Ptr->registeredTexts[5], gText_Ok);
-    StringCopy(gSaveBlock1Ptr->registeredTexts[6], gText_Sorry);
-    StringCopy(gSaveBlock1Ptr->registeredTexts[7], gText_YaySmileEmoji);
-    StringCopy(gSaveBlock1Ptr->registeredTexts[8], gText_ThankYou);
-    StringCopy(gSaveBlock1Ptr->registeredTexts[9], gText_ByeBye);
 }
 
 #define tState               data[0]


### PR DESCRIPTION
Rips out various unused parts of the save block, mystery gift, and union room chats to free up save space. It also removes the anticheat redundancy from the pokedex for additional space and simplicity.

For futureproofing, carved out:
- 10 more item slots in the bag
- 10 more key item slots in the bag
- 200 more flags
- 10 more vars
- 5 more famechecker areas
- 386 mons in the pokedex

After that, this is the space we have reserved:
- saveblock 1: 1,920 bytes
- saveblock 2: 1,084 bytes

NOTE: THIS PR WILL BREAK THE HELL OUT OF ANY SAVES YOU ARE CURRENTLY USING TO TEST