### PR TITLE
outline wonky substitute move idea

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -183,6 +183,8 @@ struct DisableStruct
     /*0x18*/ u8 mimickedMoves : 4;
     /*0x19*/ u8 rechargeTimer;
     /*0x1A*/ u8 unk1A[2];
+             u8 substitute2Layers : 2;
+             u8 padding : 6 ;
 };
 
 extern struct DisableStruct gDisableStructs[MAX_BATTLERS_COUNT];

--- a/include/constants/battle.h
+++ b/include/constants/battle.h
@@ -364,4 +364,9 @@
 // Indicator for the party summary bar to display an empty slot.
 #define HP_EMPTY_SLOT 0xFFFF
 
+// constants for substitute2 layers
+#define SUBSTITUTE2_3_LAYERS         3
+#define SUBSTITUTE2_2_LAYERS         2
+#define SUBSTITUTE2_1_LAYERS         1
+
 #endif // GUARD_CONSTANTS_BATTLE_H

--- a/include/constants/moves.h
+++ b/include/constants/moves.h
@@ -572,8 +572,9 @@
 #define MOVE_STEAMROLLER 567
 #define MOVE_SLASH_TCG 568
 #define MOVE_SWORDSDANCE_TCG 569
+#define MOVE_SUBSTITUTE_2 570
 
-#define MOVES_COUNT 570
+#define MOVES_COUNT 571
 
 // Used for checks for moves affected by Disable, Mimic, etc.
 #define MOVE_UNAVAILABLE 0xFFFF

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -829,7 +829,7 @@ void LoadBattleMonGfxAndAnimate(u8 battlerId, bool8 loadMonSprite, u8 spriteId)
 
 void TrySetBehindSubstituteSpriteBit(u8 battlerId, u16 move)
 {
-    if (move == MOVE_SUBSTITUTE || move == MOVE_SUBSTITUTE_TEACHER || MOVE_SUBSTITUTE_2)
+    if (move == MOVE_SUBSTITUTE || move == MOVE_SUBSTITUTE_TEACHER || move == MOVE_SUBSTITUTE_2)
         gBattleSpritesDataPtr->battlerData[battlerId].behindSubstitute = 1;
 }
 

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -829,7 +829,7 @@ void LoadBattleMonGfxAndAnimate(u8 battlerId, bool8 loadMonSprite, u8 spriteId)
 
 void TrySetBehindSubstituteSpriteBit(u8 battlerId, u16 move)
 {
-    if (move == MOVE_SUBSTITUTE || move == MOVE_SUBSTITUTE_TEACHER)
+    if (move == MOVE_SUBSTITUTE || move == MOVE_SUBSTITUTE_TEACHER || MOVE_SUBSTITUTE_2)
         gBattleSpritesDataPtr->battlerData[battlerId].behindSubstitute = 1;
 }
 

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1836,7 +1836,7 @@ static void Cmd_attackanimation(void)
     if (gBattleControllerExecFlags)
         return;
 
-    if ((gHitMarker & HITMARKER_NO_ANIMATIONS) && (gCurrentMove != MOVE_TRANSFORM && gCurrentMove != MOVE_SUBSTITUTE && gCurrentMove != MOVE_SUBSTITUTE_TEACHER))
+    if ((gHitMarker & HITMARKER_NO_ANIMATIONS) && (gCurrentMove != MOVE_TRANSFORM && gCurrentMove != MOVE_SUBSTITUTE && gCurrentMove != MOVE_SUBSTITUTE_TEACHER && gCurrentMove != MOVE_SUBSTITUTE_2))
     {
         BattleScriptPush(gBattlescriptCurrInstr + 1);
         gBattlescriptCurrInstr = BattleScript_Pausex20;
@@ -1973,14 +1973,42 @@ static void Cmd_datahpupdate(void)
                     gSpecialStatuses[gActiveBattler].dmg = gDisableStructs[gActiveBattler].substituteHP;
                 gHpDealt = gDisableStructs[gActiveBattler].substituteHP;
                 gDisableStructs[gActiveBattler].substituteHP = 0;
+                if (gDisableStructs[gActiveBattler].substitute2Layers > 0)
+                    gDisableStructs[gActiveBattler].substitute2Layers -= 1;
             }
             // check substitute fading
             if (gDisableStructs[gActiveBattler].substituteHP == 0)
             {
-                gBattlescriptCurrInstr += 2;
-                BattleScriptPushCursor();
-                gBattlescriptCurrInstr = BattleScript_SubstituteFade;
-                return;
+                if (gDisableStructs[gActiveBattler].substitute2Layers == 2)
+                {
+                    
+                    // reset sub hp 
+                    gDisableStructs[gActiveBattler].substituteHP = gBattleMons[gActiveBattler].maxHP / 4;
+
+                    // TODO fade the sub from layer 3 -> layer 2 by making a BattleScript_SubstituteFade2
+                    // gBattlescriptCurrInstr += 2;
+                    // BattleScriptPushCursor();
+                    // gBattlescriptCurrInstr = BattleScript_SubstituteFade2;
+                    // return;
+                }
+                else if (gDisableStructs[gActiveBattler].substitute2Layers == 1)
+                {
+                    // reset sub hp 
+                    gDisableStructs[gActiveBattler].substituteHP = gBattleMons[gActiveBattler].maxHP / 4;
+
+                    // TODO fade the sub from layer 2 -> layer 1 by making a BattleScript_SubstituteFade3
+                    // gBattlescriptCurrInstr += 2;
+                    // BattleScriptPushCursor();
+                    // gBattlescriptCurrInstr = BattleScript_SubstituteFade2;
+                    // return;
+                }
+                else 
+                {
+                    gBattlescriptCurrInstr += 2;
+                    BattleScriptPushCursor();
+                    gBattlescriptCurrInstr = BattleScript_SubstituteFade;
+                    return;
+                }
             }
         }
         else
@@ -7815,6 +7843,10 @@ static void Cmd_setsubstitute(void)
         gDisableStructs[gBattlerAttacker].substituteHP = gBattleMoveDamage;
         gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_SET_SUBSTITUTE;
         gHitMarker |= HITMARKER_IGNORE_SUBSTITUTE;
+        // TODO im not sure if this is the right check here but you get the idea
+        
+        if(gCurrentMove == MOVE_SUBSTITUTE_2)
+            gDisableStructs[gBattlerAttacker].substitute2Layers = 3;
     }
 
     gBattlescriptCurrInstr++;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1979,7 +1979,7 @@ static void Cmd_datahpupdate(void)
             // check substitute fading
             if (gDisableStructs[gActiveBattler].substituteHP == 0)
             {
-                if (gDisableStructs[gActiveBattler].substitute2Layers == 2)
+                if (gDisableStructs[gActiveBattler].substitute2Layers == SUBSTITUTE2_2_LAYERS)
                 {
                     
                     // reset sub hp 
@@ -1991,7 +1991,7 @@ static void Cmd_datahpupdate(void)
                     // gBattlescriptCurrInstr = BattleScript_SubstituteFade2;
                     // return;
                 }
-                else if (gDisableStructs[gActiveBattler].substitute2Layers == 1)
+                else if (gDisableStructs[gActiveBattler].substitute2Layers == SUBSTITUTE2_1_LAYERS)
                 {
                     // reset sub hp 
                     gDisableStructs[gActiveBattler].substituteHP = gBattleMons[gActiveBattler].maxHP / 4;
@@ -7844,9 +7844,9 @@ static void Cmd_setsubstitute(void)
         gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_SET_SUBSTITUTE;
         gHitMarker |= HITMARKER_IGNORE_SUBSTITUTE;
         // TODO im not sure if this is the right check here but you get the idea
-        
+
         if(gCurrentMove == MOVE_SUBSTITUTE_2)
-            gDisableStructs[gBattlerAttacker].substitute2Layers = 3;
+            gDisableStructs[gBattlerAttacker].substitute2Layers = SUBSTITUTE2_3_LAYERS;
     }
 
     gBattlescriptCurrInstr++;

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -7203,6 +7203,18 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .priority = 0,
         .flags = FLAG_PROTECT_AFFECTED | FLAG_MAKES_CONTACT
     },
+
+[MOVE_SUBSTITUTE_2] =       {
+        .effect = EFFECT_SUBSTITUTE,
+        .power = 0,
+        .type = TYPE_NORMAL,
+        .accuracy = 0,
+        .pp = 10,
+        .secondaryEffectChance = 0,
+        .target = MOVE_TARGET_USER,
+        .priority = 0,
+        .flags = FLAG_SNATCH_AFFECTED,
+    },
     
 
 };

--- a/src/data/text/move_names.h
+++ b/src/data/text/move_names.h
@@ -1147,5 +1147,6 @@ const u8 gLongMoveNames[MOVES_COUNT][LONG_MOVE_NAME_LENGTH + 1] = {
 [MOVE_STEAMROLLER]     = _("STEAMROLLER"),
 [MOVE_SLASH_TCG]     = _("SLASH"),
 [MOVE_SWORDSDANCE_TCG]     = _("SWORDS DANCE"),
+[MOVE_SUBSTITUTE_2]    = _("SUBSTITUTE"),
 }; //For any move which needs its name lengthened, these will display in battle.
 

--- a/src/move_descriptions.c
+++ b/src/move_descriptions.c
@@ -1147,4 +1147,5 @@ const u8 *const gMoveDescriptionPointers[MOVES_COUNT - 1] = {
     [MOVE_STEAMROLLER     -1 ] = gMoveDescription_Steamroller,
     [MOVE_SLASH_TCG     -1 ] = gMoveDescription_Slash_TCG,
     [MOVE_SWORDSDANCE_TCG     -1 ] = gMoveDescription_SwordsDance_TCG,
+    [MOVE_SUBSTITUTE_2    - 1] = gMoveDescription_Substitute,
 };


### PR DESCRIPTION
DRAFT DONT MERGE it will not work if you try to use the move substitute 2 and will probably explode when the sub fades

ok so what is missing to test this:
1) the battle script to do the "kangas made a sub, kanga's sub made a sub, kanga's sub's sub made a sub", which would be called `BattleScript_EffectSubstitute2` and the only different from the base would be strings and animations (i dont know how to make this and dont really want to try :D )

2) make an `EFFECT_SUBSTITUTE_2` that pairs with this battle script ^

3) make scripts for when the subs fade into the next layers, `BattleScript_SubstituteFade2` and `BattleScript_SubstituteFade3`, respectively

4) uncomment the code in `Cmd_datahpupdate` once those extra fade scripts are made and then give it a go