### PR TITLE
Fix already caught mons not setting "shiny found" flag

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -10010,6 +10010,10 @@ static void Cmd_trysetcaughtmondexflags(void)
 
     if (GetSetPokedexFlag(SpeciesToNationalPokedexNum(species), FLAG_GET_CAUGHT))
     {
+        // explicitly set the shiny found flag when it's a mon that has already been caught
+        if (FlagGet(FLAG_SHINY_CREATION))
+            GetSetPokedexFlag(SpeciesToNationalPokedexNum(species), FLAG_SET_SHINY_FOUND);
+
         gBattlescriptCurrInstr = T1_READ_PTR(gBattlescriptCurrInstr + 1);
     }
     else


### PR DESCRIPTION
Does what it says on the tin. Keeps the old logic for setting the shiny found flag when the caught flag is set (for new and gift mons), but also now explicitly sets the the shiny found flag when catching a mon that has already been marked caught.