### PR TITLE
Add status inflicting script command from expansion

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1736,6 +1736,14 @@
 	.byte \mode
 	.endm
 
+	@ Inflicts the given status1 condition on the party member in the given slot
+	@ If PARTY_SIZE is passed as the slot, it will inflict it on the whole party
+	.macro setstatus1 status1:req, slot:req
+	.byte 0xdf
+	.byte \status1
+	.byte \slot
+	.endm
+
 @ Supplementary
 
 	.macro goto_if_unset flag:req, dest:req

--- a/data/script_cmd_table.inc
+++ b/data/script_cmd_table.inc
@@ -224,6 +224,7 @@ gScriptCmdTable::
 	.4byte ScrCmd_fadescreenswapbuffers    		 @ 0xdc
 	.4byte ScrCmd_settilecollision    		     @ 0xdd
 	.4byte ScrCmd_fadescreeninstant              @ 0xde
+	.4byte ScrCmd_setstatus1                     @ 0xdf
 
 gScriptCmdTableEnd::
 	.4byte ScrCmd_nop

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -2470,3 +2470,26 @@ bool8 ScrCmd_checkmoncaught(struct ScriptContext * ctx)
 
     return FALSE;
 }
+
+void ScrCmd_setstatus1(struct ScriptContext *ctx)
+{
+    u32 status1 = VarGet(ScriptReadByte(ctx));
+    u32 slot = VarGet(ScriptReadByte(ctx));
+    u16 species = SPECIES_NONE;
+
+    if (slot >= PARTY_SIZE)
+    {
+        for (slot = 0; slot < PARTY_SIZE; slot++)
+        {
+            species = GetMonData(&gPlayerParty[slot], MON_DATA_SPECIES);
+            if (species != SPECIES_NONE
+             && species != SPECIES_EGG
+             && GetMonData(&gPlayerParty[slot], MON_DATA_HP) != 0)
+                SetMonData(&gPlayerParty[slot], MON_DATA_STATUS, &status1);
+        }
+    }
+    else
+    {
+        SetMonData(&gPlayerParty[slot], MON_DATA_STATUS, &status1);
+    }
+}


### PR DESCRIPTION
Adds the `setstatus1` script command from pokeemerald-expansion:
```
@ Inflicts the given status1 condition on the party member in the given slot
@ If PARTY_SIZE is passed as the slot, it will inflict it on the whole party
```