### PR TITLE
Implement nidotrans shiny secret

### DIFF
--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -440,6 +440,7 @@ void GiveBoxMonInitialMoveset_Fast(struct BoxPokemon *boxMon);
 void SetMonLockedAbility(struct Pokemon *mon, u8 ability);
 void SetBoxMonLockedAbility(struct BoxPokemon *boxMon, u8 ability);
 u16 MonTryLearningNewMoveEvolution(struct Pokemon *mon, bool8 firstMove);
+void UpdateMonPersonality(struct BoxPokemon *boxMon, u32 personality);
 
 u32 GetCurrentLevelCap(u16 species);
 

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -24,7 +24,9 @@
 #include "overworld.h"
 #include "party_menu.h"
 #include "pokedex_screen.h"
+#include "pokemon.h"
 #include "quest_log.h"
+#include "random.h"
 #include "region_map.h"
 #include "script.h"
 #include "script_pokemon_util.h"
@@ -87,6 +89,9 @@ static void StartGenderFluidFieldEffect(void);
 static void Task_GenderFluidWarpOut(u8 taskId);
 static void GenderFluidWarpOutEffect_Init(struct Task *task);
 static void GenderFluidWarpOutEffect_Spin(struct Task *task);
+static void TryToTransTheNidotrans(void);
+static void TransTheNidotrans(u16 nidoFIdx, u16 nidoMIdx);
+static u16 FindSpeciesInParty(u16 species);
 
 
 // unknown unused data.
@@ -1177,8 +1182,74 @@ static void ItemUseOnFieldCB_GenderFluid(u8 taskId)
         gSaveBlock2Ptr->playerGender = MALE;
         gPlayerAvatar.gender = MALE;
     }
+
+    TryToTransTheNidotrans();
     
     DisplayItemMessageOnField(taskId, FONT_NORMAL, gStringVar4, Task_UseGenderFluidOnField);
+}
+
+static void TryToTransTheNidotrans(void)
+{
+    u16 nidoFIdx, nidoMIdx;
+    nidoFIdx = FindSpeciesInParty(SPECIES_NIDORAN_M); 
+    nidoMIdx = FindSpeciesInParty(SPECIES_NIDORAN_F); 
+
+    // only trans 'em if they're both present
+    if (nidoFIdx == SPECIES_NONE || nidoMIdx == SPECIES_NONE)
+    {
+        return;    
+    }
+
+    TransTheNidotrans(nidoFIdx, nidoMIdx);
+}
+
+static void TransTheNidotrans(u16 nidoFIdx, u16 nidoMIdx)
+{
+    u32 newPersonality, otID, i;
+    u16 newSpecies, oldSpecies;
+    u8 nickname[POKEMON_NAME_LENGTH + 1];
+    struct Pokemon *mon;
+    bool32 thisIsTrue = TRUE;
+
+    for (i = 0; i < 2; i++)
+    {
+        mon = &gPlayerParty[i == 0 ? nidoFIdx : nidoMIdx];
+        newSpecies = i == 0 ? SPECIES_NIDORAN_F : SPECIES_NIDORAN_M;
+        oldSpecies = i == 0 ? SPECIES_NIDORAN_M : SPECIES_NIDORAN_F;
+
+        otID = GetMonData(mon, MON_DATA_OT_ID, NULL);
+        GetMonNickname(mon, nickname);
+        newPersonality = Random32();
+
+        // force the mon to be shiny
+        newPersonality = ((((Random() % SHINY_ODDS) ^ (HIHALF(otID) ^ LOHALF(otID))) ^ LOHALF(newPersonality)) << 16) | LOHALF(newPersonality);
+        
+        // if player has nicknamed their nidotran, don't overwrite it
+        if (StringCompare(nickname, gSpeciesNames[oldSpecies]) == 0)
+        {
+            SetMonData(mon, MON_DATA_NICKNAME, &gSpeciesNames[newSpecies]);
+        }
+        SetMonData(mon, MON_DATA_SPECIES, &newSpecies); 
+        SetMonData(mon, MON_DATA_CSR_SHINY, &thisIsTrue); 
+        GetSetPokedexFlag(SpeciesToNationalPokedexNum(newSpecies), FLAG_SET_SHINY_FOUND);
+        UpdateMonPersonality(&mon->box, newPersonality);
+        CalculateMonStats(mon);
+    } 
+}
+
+static u16 FindSpeciesInParty(u16 species)
+{
+    u32 i;
+    for (i = 0; i < PARTY_SIZE; i++)
+    {
+        if (GetMonData(&gPlayerParty[i], MON_DATA_SANITY_HAS_SPECIES)
+            && GetMonData(&gPlayerParty[i], MON_DATA_SPECIES_OR_EGG) == species)
+        {
+            return i;
+        }
+    }
+
+    return SPECIES_NONE;
 }
 
 static void Task_UseGenderFluidOnField(u8 taskId)

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -6680,3 +6680,31 @@ u32 GetCurrentLevelCap(u16 species)
     return MAX_LEVEL;
 }
 
+void UpdateMonPersonality(struct BoxPokemon *boxMon, u32 personality)
+{
+    struct PokemonSubstruct0 *old0, *new0;
+    struct PokemonSubstruct1 *old1, *new1;
+    struct PokemonSubstruct2 *old2, *new2;
+    struct PokemonSubstruct3 *old3, *new3;
+    struct BoxPokemon old;
+
+    old = *boxMon;
+    old0 = &(GetSubstruct(&old, old.personality, 0)->type0);
+    old1 = &(GetSubstruct(&old, old.personality, 1)->type1);
+    old2 = &(GetSubstruct(&old, old.personality, 2)->type2);
+    old3 = &(GetSubstruct(&old, old.personality, 3)->type3);
+
+    new0 = &(GetSubstruct(boxMon, personality, 0)->type0);
+    new1 = &(GetSubstruct(boxMon, personality, 1)->type1);
+    new2 = &(GetSubstruct(boxMon, personality, 2)->type2);
+    new3 = &(GetSubstruct(boxMon, personality, 3)->type3);
+
+    DecryptBoxMon(&old);
+    boxMon->personality = personality;
+    *new0 = *old0;
+    *new1 = *old1;
+    *new2 = *old2;
+    *new3 = *old3;
+    boxMon->checksum = CalculateBoxMonChecksum(boxMon);
+    EncryptBoxMon(boxMon);
+}


### PR DESCRIPTION
Implements a secret to swap the Nidotranses genders if you use Gender Fluid while they're both in your party. It forces them to become shiny and sets their CSR shiny bits plus the relevant shiny obtain flags.

![csr_the_libs_transed_my_nidos](https://github.com/user-attachments/assets/267c5e0a-b8c7-4445-a8c1-e625d968f41d)
