### PR TITLE
Implement move relearner item

### DIFF
--- a/include/constants/party_menu.h
+++ b/include/constants/party_menu.h
@@ -75,6 +75,7 @@ define FIELD_MOVE_GUILLOTINE   13
 #define PARTY_MENU_TYPE_UNION_ROOM_TRADE          9  // trading board
 #define PARTY_MENU_TYPE_SPIN_TRADE                10 // Unused beta for Gen IV's Spin Trade
 #define PARTY_MENU_TYPE_MINIGAME                  11
+#define PARTY_MENU_TYPE_MOVE_RELEARNER_ITEM       12 
 
 #define PARTY_ACTION_CHOOSE_MON         0
 #define PARTY_ACTION_SEND_OUT           1
@@ -124,6 +125,7 @@ define FIELD_MOVE_GUILLOTINE   13
 #define PARTY_MSG_CANT_USE_RETREAT          27
 #define PARTY_MSG_NO_RETREAT          28
 #define PARTY_MSG_BUT_IT_FAILED          29
+#define PARTY_MSG_NO_RELEARNS               30
 #define PARTY_MSG_NONE                      127
 
 // IDs for DisplayPartyPokemonDescriptionText, to display a message in the party pokemon's box

--- a/include/item_use.h
+++ b/include/item_use.h
@@ -44,6 +44,7 @@ u8 CanUseEscapeRopeOnCurrMap(void);
 u8 CheckIfItemIsTMHMOrEvolutionStone(u16 itemId);
 void FieldUseFunc_LWPEmblem(u8 taskId);
 void FieldUseFunc_GenderFluid(u8 taskId);
+void FieldUseFunc_MoveRelearner(u8 taskId);
 
 
 void FieldUseFunc_PayDayTM(u8 taskId);

--- a/include/learn_move.h
+++ b/include/learn_move.h
@@ -1,0 +1,6 @@
+#ifndef GUARD_LEARN_MOVE_H
+#define GUARD_LEARN_MOVE_H
+
+void Task_InitMoveRelearnerMenu(u8 taskId);
+
+#endif // GUARD_LEARN_MOVE_H

--- a/include/party_menu.h
+++ b/include/party_menu.h
@@ -84,5 +84,6 @@ void ShowPartyMenuToShowcaseMultiBattleParty(void);
 void ChooseMonForDaycare(void);
 void ChoosePartyMonByMenuType(u8 menuType);
 void LoadPartyMenuAilmentGfx(void);
+void ChooseMonForMoveRelearnerItem(void);
 
 #endif // GUARD_PARTY_MENU_H

--- a/include/strings.h
+++ b/include/strings.h
@@ -292,6 +292,7 @@ extern const u8 Pokedude_Text_PickBestKindOfBall[];
 
 // party_menu
 extern const u8 gText_ChoosePokemon[];
+extern const u8 gText_NoRelearns[];
 extern const u8 gText_ChoosePokemonCancel[];
 extern const u8 gText_ChoosePokemonConfirm[];
 extern const u8 gText_MoveToWhere[];

--- a/src/data/party_menu.h
+++ b/src/data/party_menu.h
@@ -632,6 +632,7 @@ static const u8 *const sActionStringTable[] =
     [PARTY_MSG_CANT_USE_RETREAT]       = gText_CantUseRetreat,
     [PARTY_MSG_NO_RETREAT]       = gText_NoRetreat,
     [PARTY_MSG_BUT_IT_FAILED]       = gText_ButItFailed,
+    [PARTY_MSG_NO_RELEARNS]             = gText_NoRelearns,
 };
 
 static const u8 *const sDescriptionStringTable[] =

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -87,6 +87,8 @@ static void StartGenderFluidFieldEffect(void);
 static void Task_GenderFluidWarpOut(u8 taskId);
 static void GenderFluidWarpOutEffect_Init(struct Task *task);
 static void GenderFluidWarpOutEffect_Spin(struct Task *task);
+static void ItemUseOnFieldCB_MoveRelearner(u8 taskId);
+static void Task_UseMoveRelearnerOnField(u8 taskId);
 
 
 // unknown unused data.
@@ -1264,4 +1266,23 @@ void ItemUse_SetQuestLogEvent(u8 eventId, struct Pokemon *pokemon, u16 itemId, u
         data->species = 0xFFFF;
     SetQuestLogEvent(eventId, (void *)data);
     Free(data);
+}
+
+void FieldUseFunc_MoveRelearner(u8 taskId)
+{
+    CopyItemName(gSpecialVar_ItemId, gStringVar1);
+    StringExpandPlaceholders(gStringVar4, gText_UsedTheItem);
+    sItemUseOnFieldCB = ItemUseOnFieldCB_MoveRelearner;
+    SetUpItemUseOnFieldCallback(taskId);
+}
+
+static void ItemUseOnFieldCB_MoveRelearner(u8 taskId)
+{
+    DisplayItemMessageOnField(taskId, FONT_NORMAL, gStringVar4, Task_UseMoveRelearnerOnField);
+}
+
+static void Task_UseMoveRelearnerOnField(u8 taskId)
+{
+    ChooseMonForMoveRelearnerItem();
+    DestroyTask(taskId);
 }

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -92,6 +92,8 @@ static void GenderFluidWarpOutEffect_Spin(struct Task *task);
 static void TryToTransTheNidotrans(void);
 static void TransTheNidotrans(u16 nidoFIdx, u16 nidoMIdx);
 static u16 FindSpeciesInParty(u16 species);
+static void ItemUseOnFieldCB_MoveRelearner(u8 taskId);
+static void Task_UseMoveRelearnerOnField(u8 taskId);
 
 
 // unknown unused data.
@@ -1335,4 +1337,23 @@ void ItemUse_SetQuestLogEvent(u8 eventId, struct Pokemon *pokemon, u16 itemId, u
         data->species = 0xFFFF;
     SetQuestLogEvent(eventId, (void *)data);
     Free(data);
+}
+
+void FieldUseFunc_MoveRelearner(u8 taskId)
+{
+    CopyItemName(gSpecialVar_ItemId, gStringVar1);
+    StringExpandPlaceholders(gStringVar4, gText_UsedTheItem);
+    sItemUseOnFieldCB = ItemUseOnFieldCB_MoveRelearner;
+    SetUpItemUseOnFieldCallback(taskId);
+}
+
+static void ItemUseOnFieldCB_MoveRelearner(u8 taskId)
+{
+    DisplayItemMessageOnField(taskId, FONT_NORMAL, gStringVar4, Task_UseMoveRelearnerOnField);
+}
+
+static void Task_UseMoveRelearnerOnField(u8 taskId)
+{
+    ChooseMonForMoveRelearnerItem();
+    DestroyTask(taskId);
 }

--- a/src/learn_move.c
+++ b/src/learn_move.c
@@ -8,6 +8,7 @@
 #include "overworld.h"
 #include "new_menu_helpers.h"
 #include "menu.h"
+#include "learn_move.h"
 #include "list_menu.h"
 #include "event_data.h"
 #include "text_window.h"
@@ -152,7 +153,6 @@ struct LearnMoveGfxResources
 
 static EWRAM_DATA struct LearnMoveGfxResources * sMoveRelearner = NULL;
 
-static void Task_InitMoveRelearnerMenu(u8 taskId);
 static void CB2_MoveRelearner_Init(void);
 static void CB2_MoveRelearner(void);
 static void MoveRelearnerStateMachine(void);
@@ -371,7 +371,7 @@ void TeachMoveRelearnerMove(void)
     BeginNormalPaletteFade(PALETTES_ALL, 0, 0, 16, RGB_BLACK);
 }
 
-static void Task_InitMoveRelearnerMenu(u8 taskId)
+void Task_InitMoveRelearnerMenu(u8 taskId)
 {
     if (!gPaletteFade.active)
     {

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -25,6 +25,7 @@
 #include "item.h"
 #include "item_menu.h"
 #include "item_use.h"
+#include "learn_move.h"
 #include "link.h"
 #include "link_rfu.h"
 #include "load_save.h"
@@ -1096,6 +1097,12 @@ static void Task_ClosePartyMenu(u8 taskId)
     gTasks[taskId].func = Task_ClosePartyMenuAndSetCB2;
 }
 
+static void Task_CloseAndRelearnMove(u8 taskId)
+{
+    BeginNormalPaletteFade(PALETTES_ALL, -2, 0, 16, RGB_BLACK);
+    gTasks[taskId].func = Task_InitMoveRelearnerMenu;
+}
+
 static void Task_ClosePartyMenuAndSetCB2(u8 taskId)
 {
     if (!gPaletteFade.active)
@@ -1203,11 +1210,27 @@ static void HandleChooseMonSelection(u8 taskId, s8 *slotPtr)
             SwitchSelectedMons(taskId);
             break;
         case PARTY_ACTION_CHOOSE_AND_CLOSE:
-            PlaySE(SE_SELECT);
             gSpecialVar_0x8004 = *slotPtr;
-            if (gPartyMenu.menuType == PARTY_MENU_TYPE_MOVE_RELEARNER)
+            if (gPartyMenu.menuType == PARTY_MENU_TYPE_MOVE_RELEARNER || gPartyMenu.menuType == PARTY_MENU_TYPE_MOVE_RELEARNER_ITEM)
                 gSpecialVar_0x8005 = GetNumberOfRelearnableMoves(&gPlayerParty[*slotPtr]);
-            Task_ClosePartyMenu(taskId);
+            if (gPartyMenu.menuType == PARTY_MENU_TYPE_MOVE_RELEARNER_ITEM)
+            {
+                if (gSpecialVar_0x8005 == 0)
+                {
+                    PlaySE(SE_FAILURE);
+                    DisplayPartyMenuStdMessage(PARTY_MSG_NO_RELEARNS);
+                }
+                else
+                {
+                    PlaySE(SE_SELECT);
+                    Task_CloseAndRelearnMove(taskId);
+                }
+            }
+            else
+            {
+                PlaySE(SE_SELECT);
+                Task_ClosePartyMenu(taskId);
+            }
             break;
         case PARTY_ACTION_MINIGAME:
             if (IsSelectedMonNotEgg((u8 *)slotPtr))
@@ -1377,6 +1400,12 @@ static void UpdateCurrentPartySelection(s8 *slotPtr, s8 movementDir)
         PlaySE(SE_SELECT);
         AnimatePartySlot(newSlotId, 0);
         AnimatePartySlot(*slotPtr, 1);
+    }
+        
+    // reprint choose text when using relearner item to clear the "no moves" message
+    if (gPartyMenu.menuType == PARTY_MENU_TYPE_MOVE_RELEARNER_ITEM && gSpecialVar_0x8005 == 0)
+    {
+        DisplayPartyMenuStdMessage(PARTY_MSG_CHOOSE_MON);
     }
 }
 

--- a/src/party_menu_specials.c
+++ b/src/party_menu_specials.c
@@ -31,6 +31,16 @@ void ChooseMonForMoveRelearner(void)
     BeginNormalPaletteFade(PALETTES_ALL, 0, 0, 0x10, RGB_BLACK);
 }
 
+void ChooseMonForMoveRelearnerItem(void)
+{
+    u8 taskId;
+    LockPlayerFieldControls();
+    taskId = CreateTask(Task_ChoosePartyMon, 10);
+    gSpecialVar_0x8005 = 0;
+    gTasks[taskId].data[0] = PARTY_MENU_TYPE_MOVE_RELEARNER_ITEM;
+    BeginNormalPaletteFade(PALETTES_ALL, 0, 0, 0x10, RGB_BLACK);
+}
+
 static void Task_ChoosePartyMon(u8 taskId)
 {
     if (!gPaletteFade.active)

--- a/src/strings.c
+++ b/src/strings.c
@@ -325,6 +325,7 @@ ALIGNED(4) const u8 gText_CantTradeWithTrainer[] = _("You can't trade with that\
 ALIGNED(4) const u8 gText_NotPkmnOtherTrainerWants[] = _("That isn't the type of POKéMON\nthat the other TRAINER wants.");
 ALIGNED(4) const u8 gText_ThatIsntAnEgg[] = _("That isn't an EGG.");
 const u8 gText_ChoosePokemon[] = _("Choose a POKéMON.");
+const u8 gText_NoRelearns[] = _("No moves to learn!");
 const u8 gText_MoveToWhere[] = _("Move to where?");
 const u8 gText_TeachWhichPokemon[] = _("Teach which POKéMON?");
 const u8 gText_UseOnWhichPokemon[] = _("Use on which POKéMON?");


### PR DESCRIPTION
Adds a new item function to teach mons relearnable moves. To add this effect to an item, just set the following item fields:
```json
"type": "ITEM_TYPE_FIELD",
"fieldUseFunc": "FieldUseFunc_MoveRelearner",
```
![csr_move_relearn_item](https://github.com/user-attachments/assets/b5dbd9bc-adb3-4f9a-a52d-99fae6c0040b)
