### PR TITLE
Fix oam matrix leak

### DIFF
--- a/src/rotom_menu.c
+++ b/src/rotom_menu.c
@@ -1790,7 +1790,7 @@ static void RotomStartMenu_DisableSpriteAffineModes(void)
                 gSprites[spriteID].y += (ROTOM_ICON_SIZE / 2);
             }
 
-            gSprites[spriteID].oam.affineMode = ST_OAM_AFFINE_OFF;
+            FreeSpriteOamMatrix(&gSprites[spriteID]);
         }
     }
 }


### PR DESCRIPTION
Fixes a silly memory leak that causes corruption when using tail glow with the rotom menu