### PR TITLE
Fix multichoice window height

### DIFF
--- a/src/script_menu.c
+++ b/src/script_menu.c
@@ -983,7 +983,8 @@ static void DrawMultichoiceMenuDynamic(u8 left, u8 top, u8 argc, struct ListMenu
         width = DisplayTextAndGetWidth(items[i].label, width);
     }
 
-    windowHeight = (argc < maxBeforeScroll) ? argc * 2 : maxBeforeScroll * 2;
+    if (maxBeforeScroll > 10) maxBeforeScroll = 10; // 10 is the max on screen at once
+    windowHeight = GetMCWindowHeight((argc < maxBeforeScroll) ? argc : maxBeforeScroll);
     newWidth = ConvertPixelWidthToTileWidth(width);
     left = ScriptMenu_AdjustLeftCoordFromWidth(left, newWidth);
     windowId = CreateWindowFromRect(left, top, newWidth, windowHeight);
@@ -1196,6 +1197,10 @@ static u8 GetMCWindowHeight(u8 count)
         return 13;
     case 8:
         return 14;
+    case 9:
+        return 16;
+    case 10:
+        return 18;
     default:
         return 1;
     }


### PR DESCRIPTION
Multichoice window heights were off I believe because of the FRLG font height. I used the same function GF used to determine the multichoice window height now (and tweaked it to support 9 and 10 choice menus), which seems to have addressed it.